### PR TITLE
Add path arg for globbing

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ CI runs accessibility tests against multiple URLs and reports on any issues. Thi
 
 ## Latest news from Pa11y
 
-✨ 🔜 ✨ The Pa11y team is very excited to announce plans for the successor to Pa11y Dashboard and Pa11y Webservice, codename "Sidekick". Help us define the features that you want to see by visiting the [proposal][sidekick-proposal]. ✨  
+✨ 🔜 ✨ The Pa11y team is very excited to announce plans for the successor to Pa11y Dashboard and Pa11y Webservice, codename "Sidekick". Help us define the features that you want to see by visiting the [proposal][sidekick-proposal]. ✨
 
 ---
 
@@ -27,7 +27,7 @@ CI runs accessibility tests against multiple URLs and reports on any issues. Thi
   - [Default configuration](#default-configuration)
   - [URL configuration](#url-configuration)
   - [Sitemaps](#sitemaps)
-- [Tutorials and articles](#tutorials-and-articles)  
+- [Tutorials and articles](#tutorials-and-articles)
 - [Contributing](#contributing)
 - [License](#license)
 
@@ -46,7 +46,7 @@ npm install -g pa11y-ci
 Pa11y CI can be used by running it as a command line tool, `pa11y-ci`:
 
 ```
-Usage: pa11y-ci [options]
+Usage: pa11y-ci [options] [<paths>]
 
 Options:
 
@@ -76,7 +76,7 @@ You can use the `--config` command line argument to specify a different file, wh
 }
 ```
 
-Pa11y will be run against each of the URLs in the `urls` array.
+Pa11y will be run against each of the URLs in the `urls` array and the paths specified as CLI arguments. Paths can be specified as relative, absolute and as [glob](https://github.com/isaacs/node-glob#glob) patterns.
 
 ### Default configuration
 

--- a/package.json
+++ b/package.json
@@ -22,9 +22,11 @@
     "chalk": "^1.1.3",
     "cheerio": "^0.22",
     "commander": "^2.9.0",
+    "globby": "^6.1.0",
     "lodash": "^4.17.4",
     "node-fetch": "^1.7.0",
     "pa11y": "^4.11.0",
+    "protocolify": "^2.0.0",
     "wordwrap": "^1.0.0"
   },
   "devDependencies": {

--- a/test/integration/cli-paths.js
+++ b/test/integration/cli-paths.js
@@ -1,0 +1,20 @@
+/* eslint max-len: 'off' */
+'use strict';
+
+const assert = require('proclaim');
+
+describe('pa11y-ci (with paths passed as args)', () => {
+	before(() => {
+		return global.cliCall([
+			'--config',
+			'defaults',
+			'./foo/**/*.html'
+		]);
+	});
+
+	it('uses the default config for each URL and path', () => {
+		assert.include(global.lastResult.output, 'Running Pa11y on 3 URLs');
+		assert.include(global.lastResult.output, 'foo/**/*.html');
+		assert.strictEqual(global.lastResult.code, 2);
+	});
+});


### PR DESCRIPTION
Closes https://github.com/pa11y/pa11y-ci/issues/37.

This will support running as:
```
pa11y-ci '**/*.html' foo/bar.html # quotes so that the globs are interpreted by JS not the shell
```

Added a simple test. Feedback welcome!