### PR TITLE
Fix the way configurations are loaded

### DIFF
--- a/bin/pa11y-ci.js
+++ b/bin/pa11y-ci.js
@@ -141,6 +141,9 @@ function resolveConfigPath(configPath) {
 	if (configPath[0] !== '/') {
 		configPath = path.join(process.cwd(), configPath);
 	}
+	if (/\.js(on)?$/.test(configPath)) {
+		configPath = configPath.replace(/\.js(on)?$/, '');
+	}
 	return configPath;
 }
 

--- a/test/integration/cli-config.js
+++ b/test/integration/cli-config.js
@@ -60,7 +60,7 @@ describe('pa11y-ci (with a config file that has a "js" extension)', () => {
 
 });
 
-describe('pa11y-ci (with a config file that has a specified extension)', () => {
+describe('pa11y-ci (with a config file that has a specified JSON extension)', () => {
 
 	before(() => {
 		return global.cliCall([
@@ -71,6 +71,21 @@ describe('pa11y-ci (with a config file that has a specified extension)', () => {
 
 	it('loads the expected config', () => {
 		assert.include(global.lastResult.output, 'http://localhost:8090/config-extension-json');
+	});
+
+});
+
+describe('pa11y-ci (with a config file that has a specified JS extension)', () => {
+
+	before(() => {
+		return global.cliCall([
+			'--config',
+			'extension-js.js'
+		]);
+	});
+
+	it('loads the expected config', () => {
+		assert.include(global.lastResult.output, 'http://localhost:8090/config-extension-js');
 	});
 
 });


### PR DESCRIPTION
Currently loading JavaScript config files will only work if you left out
the ".js" extension. This is counterintuitive, so I now remove the
extension when we resolve the config file path.

I've tested this with the following:

  - The default `.pa11yci` config file with JSON contents
  - The default `.pa11yci.js` config file with JS contents
  - JSON config without a `.json` extension
  - JS config without a `.js` extension
  - JSON config with a `.json` extension
  - JS config with a `.js` extension

This resolves #39