### PR TITLE
Update Pa11y version to new 5.0.0 and fix broken tests

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,3 @@
 'use strict';
 
-module.exports = require('pa11y-lint-config/eslint/es6');
+module.exports = require('pa11y-lint-config/eslint/es2017');

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,11 @@ matrix:
   include:
 
     # Run linter once
-    - node_js: '6'
+    - node_js: '8'
       env: LINT=true
 
     # Run tests
-    - node_js: '4'
-    - node_js: '5'
-    - node_js: '6'
+    - node_js: '8'
 
 # Global environment variables
 env:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
 include Makefile.node
 
-export INTEGRATION_TIMEOUT := 5000
+export INTEGRATION_TIMEOUT := 7000
 export INTEGRATION_SLOW := 4000

--- a/lib/pa11y-ci.js
+++ b/lib/pa11y-ci.js
@@ -48,7 +48,6 @@ function pa11yCi(urls, options) {
 		delete options.log;
 
 		// Create a Pa11y test function and an async queue
-		const pa11yTest = pa11y(options);
 		const taskQueue = queue(testRunner, options.concurrency);
 		taskQueue.drain = testRunComplete;
 
@@ -67,32 +66,39 @@ function pa11yCi(urls, options) {
 
 		// This is the actual test runner, which the queue will
 		// execute on each of the URLs
-		function testRunner(config, done) {
-			const url = (typeof config === 'string' ? config : config.url);
+		async function testRunner(config) {
+			let url;
+			if (typeof config === 'string') {
+				url = config;
+				config = options;
+			} else {
+				url = config.url;
+				config = defaults({}, config, options);
+			}
 
 			// Run the Pa11y test on the current URL and add
 			// results to the report object
-			pa11yTest.run(config, (error, results) => {
-				if (error) {
-					log.error(` ${chalk.cyan('>')} ${url} - ${chalk.red('Failed to run')}`);
-					report.results[url] = [error];
-					return done();
-				}
-				const errors = results.filter(filterNonErrors);
+
+			try {
+				const results = await pa11y(url, config);
+
 				let message = ` ${chalk.cyan('>')} ${url} - `;
-				if (errors.length) {
-					message += chalk.red(`${errors.length} errors`);
+				if (results.issues.length) {
+					message += chalk.red(`${results.issues.length} errors`);
 					log.error(message);
-					report.results[url] = errors;
-					report.errors += errors.length;
+					report.results[url] = results.issues;
+					report.errors += results.issues.length;
 				} else {
-					message += chalk.green(`${errors.length} errors`);
+					message += chalk.green(`${results.issues.length} errors`);
 					log.info(message);
 					report.results[url] = [];
 					report.passes += 1;
 				}
-				done();
-			});
+			} catch (error) {
+				log.error(` ${chalk.cyan('>')} ${url} - ${chalk.red('Failed to run')}`);
+				report.results[url] = [error];
+			}
+
 		}
 
 		// This function is called once all of the URLs in the
@@ -136,9 +142,4 @@ function pa11yCi(urls, options) {
 		}
 
 	});
-}
-
-// Just a utility function to filter out non errors
-function filterNonErrors(result) {
-	return result.type === 'error';
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pa11y-ci",
-  "version": "2.0.0-alpha",
+  "version": "2.0.0-beta",
   "description": "Pa11y CI is a CI-centric accessibility test runner, built using Pa11y",
   "keywords": [],
   "author": "Team Pa11y",
@@ -24,7 +24,7 @@
     "commander": "^2.9.0",
     "lodash": "^4.17.4",
     "node-fetch": "^1.7.0",
-    "pa11y": "beta",
+    "pa11y": "^5.0.0",
     "wordwrap": "^1.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pa11y-ci",
-  "version": "1.2.0",
+  "version": "2.0.0-alpha",
   "description": "Pa11y CI is a CI-centric accessibility test runner, built using Pa11y",
   "keywords": [],
   "author": "Team Pa11y",
@@ -24,7 +24,7 @@
     "commander": "^2.9.0",
     "lodash": "^4.17.4",
     "node-fetch": "^1.7.0",
-    "pa11y": "^4.11.0",
+    "pa11y": "beta",
     "wordwrap": "^1.0.0"
   },
   "devDependencies": {
@@ -32,7 +32,7 @@
     "mocha": "^3.4.2",
     "mockery": "^2.0.0",
     "nyc": "^11.0.1",
-    "pa11y-lint-config": "^1.0.0",
+    "pa11y-lint-config": "^1.2.0",
     "proclaim": "^3.4.4",
     "sinon": "^2.3.2"
   },

--- a/test/integration/cli-erroring.js
+++ b/test/integration/cli-erroring.js
@@ -22,7 +22,7 @@ describe('pa11y-ci (with a single erroring URL)', () => {
 
 	it('outputs error information', () => {
 		assert.include(global.lastResult.output, 'Errors in http://notahost:8090/erroring-1');
-		assert.include(global.lastResult.output, 'Error opening url "http://notahost:8090/erroring-1" : Host notahost not found');
+		assert.include(global.lastResult.output, 'Failed to navigate: http://notahost:8090/erroring-1');
 	});
 
 	it('outputs a total erroring notice', () => {
@@ -51,7 +51,7 @@ describe('pa11y-ci (with multiple erroring URLs)', () => {
 
 	it('outputs error information', () => {
 		assert.include(global.lastResult.output, 'Errors in http://notahost:8090/erroring-1');
-		assert.include(global.lastResult.output, 'Error opening url "http://notahost:8090/erroring-1" : Host notahost not found');
+		assert.include(global.lastResult.output, 'Failed to navigate: http://notahost:8090/erroring-1');
 		assert.include(global.lastResult.output, 'Errors in http://localhost:8090/timeout');
 		assert.include(global.lastResult.output, 'timed out');
 	});

--- a/test/integration/cli-erroring.js
+++ b/test/integration/cli-erroring.js
@@ -22,7 +22,7 @@ describe('pa11y-ci (with a single erroring URL)', () => {
 
 	it('outputs error information', () => {
 		assert.include(global.lastResult.output, 'Errors in http://notahost:8090/erroring-1');
-		assert.include(global.lastResult.output, 'Failed to navigate: http://notahost:8090/erroring-1');
+		assert.include(global.lastResult.output, 'net::ERR_NAME_NOT_RESOLVED');
 	});
 
 	it('outputs a total erroring notice', () => {
@@ -51,7 +51,7 @@ describe('pa11y-ci (with multiple erroring URLs)', () => {
 
 	it('outputs error information', () => {
 		assert.include(global.lastResult.output, 'Errors in http://notahost:8090/erroring-1');
-		assert.include(global.lastResult.output, 'Failed to navigate: http://notahost:8090/erroring-1');
+		assert.include(global.lastResult.output, 'net::ERR_NAME_NOT_RESOLVED');
 		assert.include(global.lastResult.output, 'Errors in http://localhost:8090/timeout');
 		assert.include(global.lastResult.output, 'timed out');
 	});

--- a/test/integration/cli-json.js
+++ b/test/integration/cli-json.js
@@ -22,7 +22,7 @@ describe('pa11y-ci (with the `--json` flag set)', () => {
 			results: {
 				'http://notahost:8090/erroring-1': [
 					{
-						message: 'Failed to navigate: http://notahost:8090/erroring-1'
+						message: 'net::ERR_NAME_NOT_RESOLVED'
 					}
 				],
 				'http://localhost:8090/failing-1': [

--- a/test/integration/cli-json.js
+++ b/test/integration/cli-json.js
@@ -22,7 +22,7 @@ describe('pa11y-ci (with the `--json` flag set)', () => {
 			results: {
 				'http://notahost:8090/erroring-1': [
 					{
-						message: 'Error opening url "http://notahost:8090/erroring-1" : Host notahost not found'
+						message: 'Failed to navigate: http://notahost:8090/erroring-1'
 					}
 				],
 				'http://localhost:8090/failing-1': [

--- a/test/integration/cli-mixed.js
+++ b/test/integration/cli-mixed.js
@@ -24,7 +24,7 @@ describe('pa11y-ci (with erroring, failing, and passing URLs)', () => {
 
 	it('outputs error information', () => {
 		assert.include(global.lastResult.output, 'Errors in http://notahost:8090/erroring-1');
-		assert.include(global.lastResult.output, 'Error opening url "http://notahost:8090/erroring-1" : Host notahost not found');
+		assert.include(global.lastResult.output, 'Failed to navigate: http://notahost:8090/erroring-1');
 		assert.include(global.lastResult.output, 'Errors in http://localhost:8090/failing-1');
 		assert.include(global.lastResult.output, 'html element should have a lang');
 		assert.notInclude(global.lastResult.output, 'Errors in http://notahost:8090/passing-1');

--- a/test/integration/cli-mixed.js
+++ b/test/integration/cli-mixed.js
@@ -24,7 +24,7 @@ describe('pa11y-ci (with erroring, failing, and passing URLs)', () => {
 
 	it('outputs error information', () => {
 		assert.include(global.lastResult.output, 'Errors in http://notahost:8090/erroring-1');
-		assert.include(global.lastResult.output, 'Failed to navigate: http://notahost:8090/erroring-1');
+		assert.include(global.lastResult.output, 'net::ERR_NAME_NOT_RESOLVED');
 		assert.include(global.lastResult.output, 'Errors in http://localhost:8090/failing-1');
 		assert.include(global.lastResult.output, 'html element should have a lang');
 		assert.notInclude(global.lastResult.output, 'Errors in http://notahost:8090/passing-1');

--- a/test/unit/mock/pa11y.mock.js
+++ b/test/unit/mock/pa11y.mock.js
@@ -4,11 +4,8 @@ const sinon = require('sinon');
 
 const pa11y = module.exports = sinon.stub();
 
-const mockTestRunner = module.exports.mockTestRunner = {
-	run: sinon.stub()
+const mockResults = module.exports.mockResults = {
+	issues: []
 };
 
-const mockResults = module.exports.mockResults = [];
-
-mockTestRunner.run.yieldsAsync(null, mockResults);
-pa11y.returns(mockTestRunner);
+pa11y.resolves(mockResults);


### PR DESCRIPTION
Tests are breaking due to a change in Puppeteer's error messaging (https://github.com/GoogleChrome/puppeteer/issues/901) and on my machine an occasional timeout.