### PR TITLE
Update Pa11y version to new 5.0.0 and fix broken tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
 include Makefile.node
 
-export INTEGRATION_TIMEOUT := 5000
+export INTEGRATION_TIMEOUT := 7000
 export INTEGRATION_SLOW := 4000

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pa11y-ci",
-  "version": "2.0.0-alpha",
+  "version": "2.0.0-beta",
   "description": "Pa11y CI is a CI-centric accessibility test runner, built using Pa11y",
   "keywords": [],
   "author": "Team Pa11y",
@@ -25,7 +25,7 @@
     "globby": "^6.1.0",
     "lodash": "^4.17.4",
     "node-fetch": "^1.7.0",
-    "pa11y": "beta",
+    "pa11y": "^5.0.0",
     "protocolify": "^2.0.0",
     "wordwrap": "^1.0.0"
   },

--- a/test/integration/cli-erroring.js
+++ b/test/integration/cli-erroring.js
@@ -22,7 +22,7 @@ describe('pa11y-ci (with a single erroring URL)', () => {
 
 	it('outputs error information', () => {
 		assert.include(global.lastResult.output, 'Errors in http://notahost:8090/erroring-1');
-		assert.include(global.lastResult.output, 'Failed to navigate: http://notahost:8090/erroring-1');
+		assert.include(global.lastResult.output, 'net::ERR_NAME_NOT_RESOLVED');
 	});
 
 	it('outputs a total erroring notice', () => {
@@ -51,7 +51,7 @@ describe('pa11y-ci (with multiple erroring URLs)', () => {
 
 	it('outputs error information', () => {
 		assert.include(global.lastResult.output, 'Errors in http://notahost:8090/erroring-1');
-		assert.include(global.lastResult.output, 'Failed to navigate: http://notahost:8090/erroring-1');
+		assert.include(global.lastResult.output, 'net::ERR_NAME_NOT_RESOLVED');
 		assert.include(global.lastResult.output, 'Errors in http://localhost:8090/timeout');
 		assert.include(global.lastResult.output, 'timed out');
 	});

--- a/test/integration/cli-json.js
+++ b/test/integration/cli-json.js
@@ -22,7 +22,7 @@ describe('pa11y-ci (with the `--json` flag set)', () => {
 			results: {
 				'http://notahost:8090/erroring-1': [
 					{
-						message: 'Failed to navigate: http://notahost:8090/erroring-1'
+						message: 'net::ERR_NAME_NOT_RESOLVED'
 					}
 				],
 				'http://localhost:8090/failing-1': [

--- a/test/integration/cli-mixed.js
+++ b/test/integration/cli-mixed.js
@@ -24,7 +24,7 @@ describe('pa11y-ci (with erroring, failing, and passing URLs)', () => {
 
 	it('outputs error information', () => {
 		assert.include(global.lastResult.output, 'Errors in http://notahost:8090/erroring-1');
-		assert.include(global.lastResult.output, 'Failed to navigate: http://notahost:8090/erroring-1');
+		assert.include(global.lastResult.output, 'net::ERR_NAME_NOT_RESOLVED');
 		assert.include(global.lastResult.output, 'Errors in http://localhost:8090/failing-1');
 		assert.include(global.lastResult.output, 'html element should have a lang');
 		assert.notInclude(global.lastResult.output, 'Errors in http://notahost:8090/passing-1');


### PR DESCRIPTION
Tests are breaking due to a change in Puppeteer's error messaging (GoogleChrome/puppeteer#901) and on my machine an occasional timeout.