### PR TITLE
Add check for url threshold config when determining pass/fail

### DIFF
--- a/lib/pa11y-ci.js
+++ b/lib/pa11y-ci.js
@@ -86,15 +86,19 @@ function pa11yCi(urls, options) {
 			// results to the report object
 			try {
 				const results = await pa11y(url, config);
+				const withinThreshold = config.threshold ? results.issues.length <= config.threshold : false;
 
 				let message = ` ${chalk.cyan('>')} ${url} - `;
-				if (results.issues.length) {
+				if (results.issues.length && !withinThreshold) {
 					message += chalk.red(`${results.issues.length} errors`);
 					log.error(message);
 					report.results[url] = results.issues;
 					report.errors += results.issues.length;
 				} else {
 					message += chalk.green(`${results.issues.length} errors`);
+					if (withinThreshold) {
+						message += chalk.green(` (within threshold of ${config.threshold})`);
+					}
 					log.info(message);
 					report.results[url] = [];
 					report.passes += 1;

--- a/test/integration/cli-passing.js
+++ b/test/integration/cli-passing.js
@@ -49,3 +49,26 @@ describe('pa11y-ci (with multiple passing URLs)', () => {
 	});
 
 });
+
+describe('pa11y-ci (with URLs passing due to threshold)', () => {
+
+	before(() => {
+		return global.cliCall([
+			'--config',
+			'passing-threshold'
+		]);
+	});
+
+	it('exits with 0', () => {
+		assert.strictEqual(global.lastResult.code, 0);
+	});
+
+	it('outputs a result notice for each URL', () => {
+		assert.include(global.lastResult.output, 'http://localhost:8090/failing-1 - 1 errors (within threshold of 1)');
+	});
+
+	it('outputs a total passing notice', () => {
+		assert.include(global.lastResult.output, '1/1 URLs passed');
+	});
+
+});

--- a/test/integration/mock/config/passing-threshold.json
+++ b/test/integration/mock/config/passing-threshold.json
@@ -1,0 +1,8 @@
+{
+	"urls": [
+		{
+      "url": "http://localhost:8090/failing-1",
+      "threshold": 1
+    }
+	]
+}

--- a/test/unit/lib/pa11y-ci.js
+++ b/test/unit/lib/pa11y-ci.js
@@ -255,6 +255,7 @@ describe('lib/pa11y-ci', () => {
 					{
 						url: 'qux-url',
 						bar: 'baz',
+						threshold: 2,
 						concurrency: 4,
 						wrapWidth: 80,
 						browser: mockBrowser
@@ -262,7 +263,14 @@ describe('lib/pa11y-ci', () => {
 				];
 
 				pa11y.reset();
-				pa11y.withArgs('qux-url', userUrls[0]).resolves({issues: []});
+				pa11y.withArgs('qux-url', userUrls[0]).resolves({issues: [
+					{
+						type: 'error',
+						message: 'Pa11y Result Error',
+						selector: '',
+						context: null
+					}
+				]});
 
 				returnedPromise = pa11yCi(userUrls, userOptions);
 			});
@@ -283,13 +291,14 @@ describe('lib/pa11y-ci', () => {
 				});
 
 				it('correctly logs the number of errors for the URL', () => {
-					assert.calledWithMatch(log.info, /qux-url.*0 errors/i);
+					assert.calledWithMatch(log.info, /qux-url.*1 errors/i);
 				});
 
 				describe('resolved object', () => {
 
 					it('has a `results` property set to an object where keys are URLs and values are their results', () => {
 						assert.isObject(report.results);
+						assert.strictEqual(report.passes, 1);
 						assert.isArray(report.results['qux-url']);
 						assert.lengthEquals(report.results['qux-url'], 0);
 					});


### PR DESCRIPTION
This enables Pa11y-CI to respect the [Pa11y threshold configuration](https://github.com/pa11y/pa11y#threshold-number) on a per url basis (if provided).

So it will be possible to pass tests even when there are errors present, as long as those errors are fewer than the threshold number given for that url.

No change to the Pa11y-CI `--threshold` flag functionality, which provides a different (aggregate) way to pass tests with errors present.