### PR TITLE
Pin puppeteer to Version 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "node-fetch": "^1.7.0",
     "pa11y": "^5.0.3",
     "protocolify": "^2.0.0",
-    "puppeteer": "^1.0.0",
+    "puppeteer": "1.0.0",
     "wordwrap": "^1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Right now, when we run a build, Chromium is downloaded twice - once for puppeteer 1.3.0 and once for puppeteer 1.0.0. To speed up our build and avoid downloading Chromium twice, we would love to have puppeteer pinned to Version 1.0.0 😄 .

There is a bug in versions of puppeteer > 1.0.0 so we have to use the older version.

This is my first pull request on someone else's repo so if I'm missing anything, let me know!

![image](https://user-images.githubusercontent.com/30316203/39186618-e83e44dc-47c2-11e8-8d8a-4d276958728a.png)


