### PR TITLE
Write 'error' and 'URL' in their singular forms when appropriate

### DIFF
--- a/lib/pa11y-ci.js
+++ b/lib/pa11y-ci.js
@@ -56,7 +56,8 @@ function pa11yCi(urls, options) {
 		taskQueue.drain = testRunComplete;
 
 		// Push the URLs on to the queue
-		log.info(chalk.cyan.underline(`Running Pa11y on ${urls.length} URLs:`));
+		log.info(chalk.cyan
+			.underline(`Running Pa11y on ${urls.length} URL${urls.length === 1 ? '' : 's'}:`));
 		taskQueue.push(urls);
 
 		// The report object is what we eventually return to
@@ -90,12 +91,12 @@ function pa11yCi(urls, options) {
 
 				let message = ` ${chalk.cyan('>')} ${url} - `;
 				if (results.issues.length && !withinThreshold) {
-					message += chalk.red(`${results.issues.length} errors`);
+					message += chalk.red(`${results.issues.length} error${results.issues.length === 1 ? '' : 's'}`);
 					log.error(message);
 					report.results[url] = results.issues;
 					report.errors += results.issues.length;
 				} else {
-					message += chalk.green(`${results.issues.length} errors`);
+					message += chalk.green(`${results.issues.length} error${results.issues.length === 1 ? '' : 's'}`);
 					if (withinThreshold) {
 						message += chalk.green(` (within threshold of ${config.threshold})`);
 					}
@@ -113,7 +114,7 @@ function pa11yCi(urls, options) {
 		// queue have been tested. It outputs the actual errors
 		// that occurred in the test as well as a pass/fail ratio
 		function testRunComplete() {
-			const passRatio = `${report.passes}/${report.total} URLs passed`;
+			const passRatio = `${report.passes}/${report.total} URL${report.passes === 1 ? '' : 's'} passed`;
 
 			testBrowser.close();
 
@@ -125,7 +126,10 @@ function pa11yCi(urls, options) {
 				const wrap = wordwrap(3, options.wrapWidth);
 				Object.keys(report.results).forEach(url => {
 					if (report.results[url].length) {
-						log.error(chalk.underline(`\nErrors in ${url}:`));
+						log.error(chalk
+							.underline(
+								`\nError${report.results[url].length === 1 ? '' : 's'} in ${url}:`
+							));
 						report.results[url].forEach(result => {
 							const redBullet = chalk.red('•');
 							if (result instanceof Error) {

--- a/test/integration/cli-erroring.js
+++ b/test/integration/cli-erroring.js
@@ -21,7 +21,7 @@ describe('pa11y-ci (with a single erroring URL)', () => {
 	});
 
 	it('outputs error information', () => {
-		assert.include(global.lastResult.output, 'Errors in http://notahost:8090/erroring-1');
+		assert.include(global.lastResult.output, 'Error in http://notahost:8090/erroring-1');
 		assert.include(global.lastResult.output, 'net::ERR_NAME_NOT_RESOLVED');
 	});
 
@@ -50,9 +50,9 @@ describe('pa11y-ci (with multiple erroring URLs)', () => {
 	});
 
 	it('outputs error information', () => {
-		assert.include(global.lastResult.output, 'Errors in http://notahost:8090/erroring-1');
+		assert.include(global.lastResult.output, 'Error in http://notahost:8090/erroring-1');
 		assert.include(global.lastResult.output, 'net::ERR_NAME_NOT_RESOLVED');
-		assert.include(global.lastResult.output, 'Errors in http://localhost:8090/timeout');
+		assert.include(global.lastResult.output, 'Error in http://localhost:8090/timeout');
 		assert.include(global.lastResult.output, 'timed out');
 	});
 

--- a/test/integration/cli-failing.js
+++ b/test/integration/cli-failing.js
@@ -17,11 +17,11 @@ describe('pa11y-ci (with a single failing URL)', () => {
 	});
 
 	it('outputs a result notice for each URL', () => {
-		assert.include(global.lastResult.output, 'http://localhost:8090/failing-1 - 1 errors');
+		assert.include(global.lastResult.output, 'http://localhost:8090/failing-1 - 1 error');
 	});
 
 	it('outputs error information', () => {
-		assert.include(global.lastResult.output, 'Errors in http://localhost:8090/failing-1');
+		assert.include(global.lastResult.output, 'Error in http://localhost:8090/failing-1');
 		assert.include(global.lastResult.output, 'html element should have a lang');
 	});
 
@@ -45,14 +45,14 @@ describe('pa11y-ci (with multiple failing URLs)', () => {
 	});
 
 	it('outputs a result notice for each URL', () => {
-		assert.include(global.lastResult.output, 'http://localhost:8090/failing-1 - 1 errors');
-		assert.include(global.lastResult.output, 'http://localhost:8090/failing-2 - 1 errors');
+		assert.include(global.lastResult.output, 'http://localhost:8090/failing-1 - 1 error');
+		assert.include(global.lastResult.output, 'http://localhost:8090/failing-2 - 1 error');
 	});
 
 	it('outputs error information', () => {
-		assert.include(global.lastResult.output, 'Errors in http://localhost:8090/failing-1');
+		assert.include(global.lastResult.output, 'Error in http://localhost:8090/failing-1');
 		assert.include(global.lastResult.output, 'html element should have a lang');
-		assert.include(global.lastResult.output, 'Errors in http://localhost:8090/failing-2');
+		assert.include(global.lastResult.output, 'Error in http://localhost:8090/failing-2');
 		assert.include(global.lastResult.output, 'title element in the head');
 	});
 

--- a/test/integration/cli-mixed.js
+++ b/test/integration/cli-mixed.js
@@ -18,20 +18,20 @@ describe('pa11y-ci (with erroring, failing, and passing URLs)', () => {
 
 	it('outputs a result notice for each URL', () => {
 		assert.include(global.lastResult.output, 'http://notahost:8090/erroring-1 - Failed to run');
-		assert.include(global.lastResult.output, 'http://localhost:8090/failing-1 - 1 errors');
+		assert.include(global.lastResult.output, 'http://localhost:8090/failing-1 - 1 error');
 		assert.include(global.lastResult.output, 'http://localhost:8090/passing-1 - 0 errors');
 	});
 
 	it('outputs error information', () => {
-		assert.include(global.lastResult.output, 'Errors in http://notahost:8090/erroring-1');
+		assert.include(global.lastResult.output, 'Error in http://notahost:8090/erroring-1');
 		assert.include(global.lastResult.output, 'net::ERR_NAME_NOT_RESOLVED');
-		assert.include(global.lastResult.output, 'Errors in http://localhost:8090/failing-1');
+		assert.include(global.lastResult.output, 'Error in http://localhost:8090/failing-1');
 		assert.include(global.lastResult.output, 'html element should have a lang');
-		assert.notInclude(global.lastResult.output, 'Errors in http://notahost:8090/passing-1');
+		assert.notInclude(global.lastResult.output, 'Error in http://notahost:8090/passing-1');
 	});
 
 	it('outputs a total failing notice', () => {
-		assert.include(global.lastResult.output, '1/3 URLs passed');
+		assert.include(global.lastResult.output, '1/3 URL passed');
 	});
 
 });

--- a/test/integration/cli-passing.js
+++ b/test/integration/cli-passing.js
@@ -21,7 +21,7 @@ describe('pa11y-ci (with a single passing URL)', () => {
 	});
 
 	it('outputs a total passing notice', () => {
-		assert.include(global.lastResult.output, '1/1 URLs passed');
+		assert.include(global.lastResult.output, '1/1 URL passed');
 	});
 
 });
@@ -64,11 +64,11 @@ describe('pa11y-ci (with URLs passing due to threshold)', () => {
 	});
 
 	it('outputs a result notice for each URL', () => {
-		assert.include(global.lastResult.output, 'http://localhost:8090/failing-1 - 1 errors (within threshold of 1)');
+		assert.include(global.lastResult.output, 'http://localhost:8090/failing-1 - 1 error (within threshold of 1)');
 	});
 
 	it('outputs a total passing notice', () => {
-		assert.include(global.lastResult.output, '1/1 URLs passed');
+		assert.include(global.lastResult.output, '1/1 URL passed');
 	});
 
 });

--- a/test/unit/lib/pa11y-ci.js
+++ b/test/unit/lib/pa11y-ci.js
@@ -152,17 +152,17 @@ describe('lib/pa11y-ci', () => {
 
 			it('logs the number of errors for each URL, or if they fail to run', () => {
 				assert.calledWithMatch(log.info, /foo-url.*0 errors/i);
-				assert.calledWithMatch(log.error, /bar-url.*1 errors/i);
+				assert.calledWithMatch(log.error, /bar-url.*1 error/i);
 				assert.calledWithMatch(log.error, /baz-url.*failed to run/i);
 			});
 
 			it('logs the pass/fail ratio', () => {
-				assert.calledWithMatch(log.error, /1\/3 urls passed/i);
+				assert.calledWithMatch(log.error, /1\/3 URL passed/i);
 			});
 
 			it('logs the errors for each URL that has some', () => {
-				assert.neverCalledWithMatch(log.error, /errors in foo-url/i);
-				assert.calledWithMatch(log.error, /errors in bar-url/i);
+				assert.neverCalledWithMatch(log.error, /error in foo-url/i);
+				assert.calledWithMatch(log.error, /error in bar-url/i);
 				assert.calledWithMatch(log.error, /pa11y error/i);
 				assert.calledWithMatch(log.error, /pa11y result error/i);
 				assert.neverCalledWithMatch(log.error, /pa11y result warning/i);
@@ -291,7 +291,7 @@ describe('lib/pa11y-ci', () => {
 				});
 
 				it('correctly logs the number of errors for the URL', () => {
-					assert.calledWithMatch(log.info, /qux-url.*1 errors/i);
+					assert.calledWithMatch(log.info, /qux-url.*1 error/i);
 				});
 
 				describe('resolved object', () => {


### PR DESCRIPTION
This PR fixes the plural form of "errors" to be singular when appropriate.