### PR TITLE
Capture Screen Per URL in a sitemap

### DIFF
--- a/bin/pa11y-ci.js
+++ b/bin/pa11y-ci.js
@@ -231,6 +231,16 @@ function loadSitemapIntoConfig(program, config) {
 				if (sitemapFind) {
 					url = url.replace(sitemapFind, sitemapReplace);
 				}
+
+				// If default screenCapture is set, the screen captured per url in sitemap.
+				// The filename should be like /abs/path/to/filename.png, the "filename" is replaced.
+				if (config.defaults.screenCapture) {
+					url = {
+						"url": url, 
+						"screenCapture": config.defaults.screenCapture.replace('filename', url.replace(/\//g, ''))
+					}
+				}
+
 				config.urls.push(url);
 			});
 


### PR DESCRIPTION
The "**screenCapture**" option should be set under "**config.defaults**" array when a sitemap is used.

The value should contain "**filename**" and It will be replaced with a string created from URL.

Closes #72 