### PR TITLE
Allow loaded config to return promises

### DIFF
--- a/bin/pa11y-ci.js
+++ b/bin/pa11y-ci.js
@@ -129,7 +129,11 @@ function loadConfig(configPath) {
 				new Error(`There was a problem loading "${configPath}":\n${error.stack}`)
 			);
 		}
-		resolve(defaultConfig(config || {}));
+
+		// Allow loaded configs to return a promise
+		Promise.resolve(config).then(config => {
+			resolve(defaultConfig(config || {}));
+		});
 	});
 }
 

--- a/test/integration/cli-config.js
+++ b/test/integration/cli-config.js
@@ -60,6 +60,21 @@ describe('pa11y-ci (with a config file that has a "js" extension)', () => {
 
 });
 
+describe('pa11y-ci (with a config file that has a "js" extension that returns a promise)', () => {
+
+	before(() => {
+		return global.cliCall([
+			'--config',
+			'extension-js-promise'
+		]);
+	});
+
+	it('loads the expected config', () => {
+		assert.include(global.lastResult.output, 'http://localhost:8090/config-extension-js-promise');
+	});
+
+});
+
 describe('pa11y-ci (with a config file that has a specified JSON extension)', () => {
 
 	before(() => {

--- a/test/integration/mock/config/extension-js-promise.js
+++ b/test/integration/mock/config/extension-js-promise.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = Promise.resolve({
+	urls: [
+		'http://localhost:8090/config-extension-js-promise'
+	]
+});


### PR DESCRIPTION
Configs with the extension JS could return a promise rather than the
config object. This is handled by wrapping in a resolving promise
before resolving the fully loaded config.