### PR TITLE
Use a new browser for each test

### DIFF
--- a/lib/pa11y-ci.js
+++ b/lib/pa11y-ci.js
@@ -37,9 +37,9 @@ module.exports.defaults = {
 // against the passed in URLs. It accepts options in the form
 // of an object and returns a Promise
 function pa11yCi(urls, options) {
-	return new Promise(async resolve => {
-		// Create a test browser to assign to tests
-		const testBrowser = await puppeteer.launch(options.chromeLaunchConfig);
+	return new Promise(resolve => {
+		// Hold all test browsers assigned to tests
+		const testBrowsers = [];
 
 		// Default the passed in options
 		options = defaults({}, options, module.exports.defaults);
@@ -80,7 +80,8 @@ function pa11yCi(urls, options) {
 				config = defaults({}, config, options);
 			}
 
-			config.browser = testBrowser;
+			config.browser = await puppeteer.launch(options.chromeLaunchConfig);
+			testBrowsers.push(config.browser);
 
 			// Run the Pa11y test on the current URL and add
 			// results to the report object
@@ -115,7 +116,7 @@ function pa11yCi(urls, options) {
 		function testRunComplete() {
 			const passRatio = `${report.passes}/${report.total} URLs passed`;
 
-			testBrowser.close();
+			testBrowsers.forEach(testBrowser => testBrowser.close());
 
 			if (report.passes === report.total) {
 				log.info(chalk.green(`\n✔ ${passRatio}`));


### PR DESCRIPTION
Using the same browser for each test was causing concurrency issues
in tests that were updating headers.