### PR TITLE
Minor refactoring to address eslint warnings

### DIFF
--- a/bin/pa11y-ci.js
+++ b/bin/pa11y-ci.js
@@ -16,11 +16,11 @@ const path = require('path');
 const globby = require('globby');
 const protocolify = require('protocolify');
 const pkg = require('../package.json');
-const program = require('commander');
+const commander = require('commander');
 
 
 // Here we're using Commander to specify the CLI options
-program
+commander
 	.version(pkg.version)
 	.usage('[options] <paths>')
 	.option(
@@ -55,7 +55,7 @@ program
 	.parse(process.argv);
 
 // Parse the args into valid paths using glob and protocolify
-const urls = globby.sync(program.args, {
+const urls = globby.sync(commander.args, {
 	// Ensure not-found paths (like "google.com"), are returned
 	nonull: true
 }).map(protocolify);
@@ -64,12 +64,12 @@ const urls = globby.sync(program.args, {
 Promise.resolve()
 	.then(() => {
 		// Load config based on the `--config` flag
-		return loadConfig(program.config);
+		return loadConfig(commander.config);
 	})
 	.then(config => {
 		// Load a sitemap based on the `--sitemap` flag
-		if (program.sitemap) {
-			return loadSitemapIntoConfig(program, config);
+		if (commander.sitemap) {
+			return loadSitemapIntoConfig(commander, config);
 		}
 		return config;
 	})
@@ -79,7 +79,7 @@ Promise.resolve()
 	})
 	.then(report => {
 		// Output JSON if asked for it
-		if (program.json) {
+		if (commander.json) {
 			console.log(JSON.stringify(report, (key, value) => {
 				if (value instanceof Error) {
 					return {
@@ -91,7 +91,7 @@ Promise.resolve()
 		}
 		// Decide on an exit code based on whether
 		// errors are below threshold or everything passes
-		if (report.errors >= parseInt(program.threshold, 10) && report.passes < report.total) {
+		if (report.errors >= parseInt(commander.threshold, 10) && report.passes < report.total) {
 			process.exit(2);
 		} else {
 			process.exit(0);
@@ -121,7 +121,7 @@ function loadConfig(configPath) {
 			if (!config) {
 				config = loadLocalConfigWithJson(configPath);
 			}
-			if (program.config && !config) {
+			if (commander.config && !config) {
 				return reject(new Error(`The config file "${configPath}" could not be loaded`));
 			}
 		} catch (error) {
@@ -193,7 +193,7 @@ function defaultConfig(config) {
 	config.defaults.log = config.defaults.log || console;
 	// 	Setting to undefined rather than 0 allows for a fallback to the default
 	config.defaults.wrapWidth = process.stdout.columns || undefined;
-	if (program.json) {
+	if (commander.json) {
 		delete config.defaults.log;
 	}
 	return config;
@@ -201,23 +201,22 @@ function defaultConfig(config) {
 
 // Load a sitemap from a remote URL, parse out the
 // URLs, and add them to an existing config object
-function loadSitemapIntoConfig(programWithSitemap, initialConfig) {
-	const sitemapUrl = programWithSitemap.sitemap;
+function loadSitemapIntoConfig(program, initialConfig) {
 	const sitemapFind = (
-		programWithSitemap.sitemapFind ?
-		new RegExp(programWithSitemap.sitemapFind, 'gi') :
+		program.sitemapFind ?
+		new RegExp(program.sitemapFind, 'gi') :
 		null
 	);
-	const sitemapReplace = programWithSitemap.sitemapReplace || '';
+	const sitemapReplace = program.sitemapReplace || '';
 	const sitemapExclude = (
-		programWithSitemap.sitemapExclude ?
-		new RegExp(programWithSitemap.sitemapExclude, 'gi') :
+		program.sitemapExclude ?
+		new RegExp(program.sitemapExclude, 'gi') :
 		null
 	);
 
-	function getUrlsFromSitemap(aSitemapUrl, config) {
+	function getUrlsFromSitemap(sitemapUrl, config) {
 		return Promise.resolve()
-		.then(() => fetch(aSitemapUrl))
+		.then(() => fetch(sitemapUrl))
 		.then(response => response.text())
 		.then(body => {
 			const $ = cheerio.load(body, {xmlMode: true});
@@ -246,11 +245,11 @@ function loadSitemapIntoConfig(programWithSitemap, initialConfig) {
 		})
 		.catch(error => {
 			if (error.stack && error.stack.includes('node-fetch')) {
-				throw new Error(`The sitemap "${aSitemapUrl}" could not be loaded`);
+				throw new Error(`The sitemap "${sitemapUrl}" could not be loaded`);
 			}
-			throw new Error(`The sitemap "${aSitemapUrl}" could not be parsed`);
+			throw new Error(`The sitemap "${sitemapUrl}" could not be parsed`);
 		});
 	}
 
-	return getUrlsFromSitemap(sitemapUrl, initialConfig);
+	return getUrlsFromSitemap(program.sitemap, initialConfig);
 }

--- a/lib/pa11y-ci.js
+++ b/lib/pa11y-ci.js
@@ -116,7 +116,7 @@ function pa11yCi(urls, options) {
 			// results to the report object
 			try {
 				const results = await pa11y(url, config);
-				processResults({results,
+				processResults(results, config, url)
 					reportConfig: config,
 					url});
 			} catch (error) {

--- a/lib/pa11y-ci.js
+++ b/lib/pa11y-ci.js
@@ -70,7 +70,7 @@ function pa11yCi(urls, options) {
 			results: {}
 		};
 
-		function processResults({results, reportConfig, url}) {
+		function processResults(results, reportConfig, url) {
 			const withinThreshold = reportConfig.threshold ?
 					results.issues.length <= reportConfig.threshold :
 					false;

--- a/lib/pa11y-ci.js
+++ b/lib/pa11y-ci.js
@@ -15,6 +15,7 @@ const puppeteer = require('puppeteer');
 // Just an empty function to use as default
 // configuration and arguments
 /* istanbul ignore next */
+// eslint-disable-next-line no-empty-function
 const noop = () => {};
 
 // Here's the exports. `pa11yCi` is defined further down the
@@ -69,6 +70,30 @@ function pa11yCi(urls, options) {
 			results: {}
 		};
 
+		function processResults({results, reportConfig, url}) {
+			const withinThreshold = reportConfig.threshold ?
+					results.issues.length <= reportConfig.threshold :
+					false;
+
+			let message = ` ${chalk.cyan('>')} ${url} - `;
+			if (results.issues.length && !withinThreshold) {
+				message += chalk.red(`${results.issues.length} errors`);
+				log.error(message);
+				report.results[url] = results.issues;
+				report.errors += results.issues.length;
+			} else {
+				message += chalk.green(`${results.issues.length} errors`);
+				if (withinThreshold) {
+					message += chalk.green(
+						` (within threshold of ${reportConfig.threshold})`
+					);
+				}
+				log.info(message);
+				report.results[url] = [];
+				report.passes += 1;
+			}
+		}
+
 		// This is the actual test runner, which the queue will
 		// execute on each of the URLs
 		async function testRunner(config) {
@@ -91,23 +116,9 @@ function pa11yCi(urls, options) {
 			// results to the report object
 			try {
 				const results = await pa11y(url, config);
-				const withinThreshold = config.threshold ? results.issues.length <= config.threshold : false;
-
-				let message = ` ${chalk.cyan('>')} ${url} - `;
-				if (results.issues.length && !withinThreshold) {
-					message += chalk.red(`${results.issues.length} errors`);
-					log.error(message);
-					report.results[url] = results.issues;
-					report.errors += results.issues.length;
-				} else {
-					message += chalk.green(`${results.issues.length} errors`);
-					if (withinThreshold) {
-						message += chalk.green(` (within threshold of ${config.threshold})`);
-					}
-					log.info(message);
-					report.results[url] = [];
-					report.passes += 1;
-				}
+				processResults({results,
+					reportConfig: config,
+					url});
 			} catch (error) {
 				log.error(` ${chalk.cyan('>')} ${url} - ${chalk.red('Failed to run')}`);
 				report.results[url] = [error];
@@ -136,7 +147,9 @@ function pa11yCi(urls, options) {
 							if (result instanceof Error) {
 								log.error(`\n ${redBullet} Error: ${wrap(result.message).trim()}`);
 							} else {
-								const context = (result.context ? result.context.replace(/\s+/g, ' ') : '[no context]');
+								const context = result.context ?
+									result.context.replace(/\s+/g, ' ') :
+									'[no context]';
 								log.error([
 									'',
 									` ${redBullet} ${wrap(result.message).trim()}`,

--- a/lib/pa11y-ci.js
+++ b/lib/pa11y-ci.js
@@ -116,9 +116,7 @@ function pa11yCi(urls, options) {
 			// results to the report object
 			try {
 				const results = await pa11y(url, config);
-				processResults(results, config, url)
-					reportConfig: config,
-					url});
+				processResults(results, config, url);
 			} catch (error) {
 				log.error(` ${chalk.cyan('>')} ${url} - ${chalk.red('Failed to run')}`);
 				report.results[url] = [error];

--- a/test/unit/lib/pa11y-ci.js
+++ b/test/unit/lib/pa11y-ci.js
@@ -40,8 +40,6 @@ describe('lib/pa11y-ci', () => {
 	});
 
 	describe('.defaults', () => {
-		let defaults;
-
 		beforeEach(() => {
 			defaults = pa11yCi.defaults;
 		});


### PR DESCRIPTION
Warnings can be innocuous, but they can also sometimes conceal problems.  This pull request is an effort to ONLY address warnings that had been produced by `eslint` and ultimately not to change any logic or intent within.  