### PR TITLE
Version 2.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 
 # Changelog
 
+## 2.3.1 (2020-08-17)
+
+  * Add missing puppeteer dependency
+
 ## 2.3.0 (2019-05-14)
 
   * Add useIncognitoBrowserContext option for test runs

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pa11y-ci",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Pa11y CI is a CI-centric accessibility test runner, built using Pa11y",
   "keywords": [],
   "author": "Team Pa11y",


### PR DESCRIPTION
Please notice this is the 2.3.1 bugfix release of pa11y-ci.

There's been further changes to the main branch of pa11y-ci, which is why this PR is against the `2.3.x` branch.