### PR TITLE
Replace chalk with kleur

### DIFF
--- a/lib/pa11y-ci.js
+++ b/lib/pa11y-ci.js
@@ -5,12 +5,12 @@
 //
 'use strict';
 
-const chalk = require('chalk');
 const defaults = require('lodash/defaultsDeep');
 const pa11y = require('pa11y');
 const queue = require('async/queue');
-const wordwrap = require('wordwrap');
 const puppeteer = require('puppeteer');
+const reporter = require('pa11y-reporter-cli');
+const {cyan, red, green, underline} = require('kleur');
 
 // Just an empty function to use as default
 // configuration and arguments
@@ -58,7 +58,7 @@ function pa11yCi(urls, options) {
 		taskQueue.drain = testRunComplete;
 
 		// Push the URLs on to the queue
-		log.info(chalk.cyan.underline(`Running Pa11y on ${urls.length} URLs:`));
+		log.info(cyan(underline(`Running Pa11y on ${urls.length} URLs:`)));
 		taskQueue.push(urls);
 
 		// The report object is what we eventually return to
@@ -75,18 +75,16 @@ function pa11yCi(urls, options) {
 					results.issues.length <= reportConfig.threshold :
 					false;
 
-			let message = ` ${chalk.cyan('>')} ${url} - `;
+			let message = ` ${cyan('>')} ${url} - `;
 			if (results.issues.length && !withinThreshold) {
-				message += chalk.red(`${results.issues.length} errors`);
+				message += red(`${results.issues.length} errors`);
 				log.error(message);
 				report.results[url] = results.issues;
 				report.errors += results.issues.length;
 			} else {
-				message += chalk.green(`${results.issues.length} errors`);
+				message += green(`${results.issues.length} errors`);
 				if (withinThreshold) {
-					message += chalk.green(
-						` (within threshold of ${reportConfig.threshold})`
-					);
+					message += green(` (within threshold of ${reportConfig.threshold})`);
 				}
 				log.info(message);
 				report.results[url] = [];
@@ -115,7 +113,7 @@ function pa11yCi(urls, options) {
 				const results = await pa11y(url, config);
 				processResults(results, config, url);
 			} catch (error) {
-				log.error(` ${chalk.cyan('>')} ${url} - ${chalk.red('Failed to run')}`);
+				log.error(` ${cyan('>')} ${url} - ${red('Failed to run')}`);
 				report.results[url] = [error];
 			} finally {
 				if (config.useIncognitoBrowserContext) {
@@ -133,35 +131,28 @@ function pa11yCi(urls, options) {
 			testBrowser.close();
 
 			if (report.passes === report.total) {
-				log.info(chalk.green(`\n✔ ${passRatio}`));
+				log.info(green(`\n✔ ${passRatio}`));
 			} else {
-				// Now we loop over the errors and output them with
-				// word wrapping
-				const wrap = wordwrap(3, options.wrapWidth);
+				// Now loop over the errors and output the details
 				Object.keys(report.results).forEach(url => {
 					if (report.results[url].length) {
-						log.error(chalk.underline(`\nErrors in ${url}:`));
-						report.results[url].forEach(result => {
-							const redBullet = chalk.red('•');
-							if (result instanceof Error) {
-								log.error(`\n ${redBullet} Error: ${wrap(result.message).trim()}`);
-							} else {
-								const context = result.context ?
-									result.context.replace(/\s+/g, ' ') :
-									'[no context]';
-								log.error([
-									'',
-									` ${redBullet} ${wrap(result.message).trim()}`,
-									'',
-									chalk.grey(wrap(`(${result.selector})`)),
-									'',
-									chalk.grey(wrap(context))
-								].join('\n'));
-							}
-						});
+						if (report.results[url][0] instanceof Error) {
+							// If first result is an Error, then pa11y failed to run,
+							// so log error.  Also need to log URL, which is done
+							// by pa11y-reporter-cli in the nominal case.
+							log.error(underline(`\nResults for URL: ${url}`));
+							log.error(reporter.error(report.results[url][0].message));
+						} else {
+							// In this case, pa11y executed successfully, so leverage
+							// pa11y-reporter-cli to format complete results output
+							log.error(reporter.results({
+								pageUrl: url,
+								issues: report.results[url]
+							}));
+						}
 					}
 				});
-				log.error(chalk.red(`\n✘ ${passRatio}`));
+				log.error(red(`\n✘ ${passRatio}`));
 			}
 
 			// Resolve the promise with the report

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pa11y-ci",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -375,12 +375,14 @@
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true
     },
     "ansi-styles": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "dev": true
     },
     "anymatch": {
       "version": "3.1.1",
@@ -567,6 +569,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "dev": true,
       "requires": {
         "ansi-styles": "^2.2.1",
         "escape-string-regexp": "^1.0.2",
@@ -1468,6 +1471,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dev": true,
       "requires": {
         "ansi-regex": "^2.0.0"
       }
@@ -1923,6 +1927,11 @@
       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
       "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
       "dev": true
+    },
+    "kleur": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="
     },
     "levn": {
       "version": "0.3.0",
@@ -2559,27 +2568,6 @@
         "semver": "^5.6.0"
       },
       "dependencies": {
-        "commander": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
-          "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow=="
-        }
-      }
-    },
-    "pa11y-lint-config": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/pa11y-lint-config/-/pa11y-lint-config-1.2.1.tgz",
-      "integrity": "sha512-pt9rc9lTgce/rgdbPcpzMAvbfAwydmLWqRk8fOpacXynIdE9YMyXrxU3hDxRWJ/rdXKnMheUpJPTAbizEaSJAg==",
-      "dev": true
-    },
-    "pa11y-reporter-cli": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/pa11y-reporter-cli/-/pa11y-reporter-cli-1.0.1.tgz",
-      "integrity": "sha512-k+XPl5pBU2R1J6iagGv/GpN/dP7z2cX9WXqO0ALpBwHlHN3ZSukcHCOhuLMmkOZNvufwsvobaF5mnaZxT70YyA==",
-      "requires": {
-        "chalk": "^2.1.0"
-      },
-      "dependencies": {
         "ansi-styles": {
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
@@ -2598,6 +2586,19 @@
             "supports-color": "^5.3.0"
           }
         },
+        "commander": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
+          "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow=="
+        },
+        "pa11y-reporter-cli": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/pa11y-reporter-cli/-/pa11y-reporter-cli-1.0.1.tgz",
+          "integrity": "sha512-k+XPl5pBU2R1J6iagGv/GpN/dP7z2cX9WXqO0ALpBwHlHN3ZSukcHCOhuLMmkOZNvufwsvobaF5mnaZxT70YyA==",
+          "requires": {
+            "chalk": "^2.1.0"
+          }
+        },
         "supports-color": {
           "version": "5.5.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -2606,6 +2607,20 @@
             "has-flag": "^3.0.0"
           }
         }
+      }
+    },
+    "pa11y-lint-config": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/pa11y-lint-config/-/pa11y-lint-config-1.2.1.tgz",
+      "integrity": "sha512-pt9rc9lTgce/rgdbPcpzMAvbfAwydmLWqRk8fOpacXynIdE9YMyXrxU3hDxRWJ/rdXKnMheUpJPTAbizEaSJAg==",
+      "dev": true
+    },
+    "pa11y-reporter-cli": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pa11y-reporter-cli/-/pa11y-reporter-cli-2.0.0.tgz",
+      "integrity": "sha512-lqxBgQyJZMvQ0V0SbxZttO8U2Jx0AU65kZtF+oj5wamdzWH1O93pGZN9obyhCj7C3tD6Ihz6c7Kflo5M8ieIug==",
+      "requires": {
+        "kleur": "^3.0.3"
       }
     },
     "pa11y-reporter-csv": {
@@ -3096,6 +3111,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dev": true,
       "requires": {
         "ansi-regex": "^2.0.0"
       }
@@ -3115,7 +3131,8 @@
     "supports-color": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+      "dev": true
     },
     "table": {
       "version": "3.8.3",
@@ -3324,7 +3341,8 @@
     "wordwrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "dev": true
     },
     "wrap-ansi": {
       "version": "6.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -576,6 +576,17 @@
         "has-ansi": "^2.0.0",
         "strip-ansi": "^3.0.0",
         "supports-color": "^2.0.0"
+      },
+      "dependencies": {
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        }
       }
     },
     "check-types": {
@@ -1616,6 +1627,17 @@
         "string-width": "^1.0.1",
         "strip-ansi": "^3.0.0",
         "through": "^2.3.6"
+      },
+      "dependencies": {
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        }
       }
     },
     "interpret": {
@@ -3070,6 +3092,17 @@
         "code-point-at": "^1.0.0",
         "is-fullwidth-code-point": "^1.0.0",
         "strip-ansi": "^3.0.0"
+      },
+      "dependencies": {
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        }
       }
     },
     "string.prototype.trimend": {
@@ -3108,12 +3141,20 @@
       }
     },
     "strip-ansi": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
       "dev": true,
       "requires": {
-        "ansi-regex": "^2.0.0"
+        "ansi-regex": "^5.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        }
       }
     },
     "strip-bom": {

--- a/package.json
+++ b/package.json
@@ -19,16 +19,16 @@
   },
   "dependencies": {
     "async": "~2.6.3",
-    "chalk": "~1.1.3",
     "cheerio": "~1.0.0-rc.3",
     "commander": "~2.20.3",
     "globby": "~6.1.0",
+    "kleur": "~3.0.3",
     "lodash": "~4.17.20",
     "node-fetch": "~2.6.0",
     "pa11y": "~5.3.0",
+    "pa11y-reporter-cli": "~2.0.0",
     "protocolify": "~3.0.0",
-    "puppeteer": "~1.20.0",
-    "wordwrap": "~1.0.0"
+    "puppeteer": "~1.20.0"
   },
   "devDependencies": {
     "@rowanmanning/make": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "nyc": "^15.1.0",
     "pa11y-lint-config": "^1.2.0",
     "proclaim": "^3.4.4",
-    "sinon": "^2.3.2"
+    "sinon": "^2.3.2",
+    "strip-ansi": "^6.0.0"
   },
   "main": "./lib/pa11y-ci.js",
   "bin": {

--- a/test/integration/cli-erroring.test.js
+++ b/test/integration/cli-erroring.test.js
@@ -21,7 +21,7 @@ describe('pa11y-ci (with a single erroring URL)', () => {
 	});
 
 	it('outputs error information', () => {
-		assert.include(global.lastResult.output, 'Errors in http://notahost:8090/erroring-1');
+		assert.include(global.lastResult.output, 'Results for URL: http://notahost:8090/erroring-1');
 		assert.include(global.lastResult.output, 'net::ERR_NAME_NOT_RESOLVED');
 	});
 
@@ -50,9 +50,9 @@ describe('pa11y-ci (with multiple erroring URLs)', () => {
 	});
 
 	it('outputs error information', () => {
-		assert.include(global.lastResult.output, 'Errors in http://notahost:8090/erroring-1');
+		assert.include(global.lastResult.output, 'Results for URL: http://notahost:8090/erroring-1');
 		assert.include(global.lastResult.output, 'net::ERR_NAME_NOT_RESOLVED');
-		assert.include(global.lastResult.output, 'Errors in http://localhost:8090/timeout');
+		assert.include(global.lastResult.output, 'Results for URL: http://localhost:8090/timeout');
 		assert.include(global.lastResult.output, 'timed out');
 	});
 

--- a/test/integration/cli-failing.test.js
+++ b/test/integration/cli-failing.test.js
@@ -21,7 +21,7 @@ describe('pa11y-ci (with a single failing URL)', () => {
 	});
 
 	it('outputs error information', () => {
-		assert.include(global.lastResult.output, 'Errors in http://localhost:8090/failing-1');
+		assert.include(global.lastResult.output, 'Results for URL: http://localhost:8090/failing-1');
 		assert.include(global.lastResult.output, 'html element should have a lang');
 	});
 
@@ -50,9 +50,9 @@ describe('pa11y-ci (with multiple failing URLs)', () => {
 	});
 
 	it('outputs error information', () => {
-		assert.include(global.lastResult.output, 'Errors in http://localhost:8090/failing-1');
+		assert.include(global.lastResult.output, 'Results for URL: http://localhost:8090/failing-1');
 		assert.include(global.lastResult.output, 'html element should have a lang');
-		assert.include(global.lastResult.output, 'Errors in http://localhost:8090/failing-2');
+		assert.include(global.lastResult.output, 'Results for URL: http://localhost:8090/failing-2');
 		assert.include(global.lastResult.output, 'title element in the head');
 	});
 

--- a/test/integration/cli-mixed.test.js
+++ b/test/integration/cli-mixed.test.js
@@ -23,11 +23,11 @@ describe('pa11y-ci (with erroring, failing, and passing URLs)', () => {
 	});
 
 	it('outputs error information', () => {
-		assert.include(global.lastResult.output, 'Errors in http://notahost:8090/erroring-1');
+		assert.include(global.lastResult.output, 'Results for URL: http://notahost:8090/erroring-1');
 		assert.include(global.lastResult.output, 'net::ERR_NAME_NOT_RESOLVED');
-		assert.include(global.lastResult.output, 'Errors in http://localhost:8090/failing-1');
+		assert.include(global.lastResult.output, 'Results for URL: http://localhost:8090/failing-1');
 		assert.include(global.lastResult.output, 'html element should have a lang');
-		assert.notInclude(global.lastResult.output, 'Errors in http://notahost:8090/passing-1');
+		assert.notInclude(global.lastResult.output, 'Results for URL: http://notahost:8090/passing-1');
 	});
 
 	it('outputs a total failing notice', () => {

--- a/test/integration/setup.test.js
+++ b/test/integration/setup.test.js
@@ -4,6 +4,7 @@
 const path = require('path');
 const spawn = require('child_process').spawn;
 const startWebsite = require('./mock/website');
+const stripAnsi = require('strip-ansi');
 
 before(done => {
 	startWebsite(8090, (error, server) => {
@@ -40,6 +41,9 @@ function cliCall(cliArguments) {
 		});
 		child.on('close', code => {
 			result.code = code;
+			result.output = stripAnsi(result.output);
+			result.stdout = stripAnsi(result.stdout);
+			result.stderr = stripAnsi(result.stderr);
 			global.lastResult = result;
 			resolve(result);
 		});

--- a/test/unit/lib/pa11y-ci.test.js
+++ b/test/unit/lib/pa11y-ci.test.js
@@ -60,10 +60,6 @@ describe('lib/pa11y-ci', () => {
 			assert.isFunction(defaults.log.info);
 		});
 
-		it('has a `wrapWidth` property', () => {
-			assert.strictEqual(defaults.wrapWidth, 80);
-		});
-
 		it('has a `useIncognitoBrowserContext` property', () => {
 			assert.strictEqual(defaults.useIncognitoBrowserContext, false);
 		});
@@ -161,9 +157,9 @@ describe('lib/pa11y-ci', () => {
 				assert.calledWithMatch(log.error, /1\/3 urls passed/i);
 			});
 
-			it('logs the errors for each URL that has some', () => {
-				assert.neverCalledWithMatch(log.error, /errors in foo-url/i);
-				assert.calledWithMatch(log.error, /errors in bar-url/i);
+			it('logs the results for each URL that has errors', () => {
+				assert.neverCalledWithMatch(log.error, /Results for URL: foo-url/i);
+				assert.calledWithMatch(log.error, /Results for URL: bar-url/i);
 				assert.calledWithMatch(log.error, /pa11y error/i);
 				assert.calledWithMatch(log.error, /pa11y result error/i);
 				assert.neverCalledWithMatch(log.error, /pa11y result warning/i);


### PR DESCRIPTION
This PR replaces `chalk` with `kleur` (#109), chosen for consistency with `pa11y-reporter-cli`.  It also leverages `pa11y-reporter-cli` for detailed scan result output, which eliminates a significant amount of formatting code, and makes the console output consistent with `pa11y` (#64).

Two additional notes:

- This PR also fixes the `version` property in `package-lock.json` (whichnpm caught when changing dependencies)
- `wordwrap` was removed since the applicable output is now all generated with `pa11y-reporter-cli`, but it does not wrap

