### PR TITLE
Update integration tests to remove DNS dependencies

### DIFF
--- a/test/integration/cli-erroring.test.js
+++ b/test/integration/cli-erroring.test.js
@@ -17,12 +17,12 @@ describe('pa11y-ci (with a single erroring URL)', () => {
 	});
 
 	it('outputs a result notice for each URL', () => {
-		assert.include(global.lastResult.output, 'http://notahost:8090/erroring-1 - Failed to run');
+		assert.include(global.lastResult.output, './foo/erroring.html - Failed to run');
 	});
 
 	it('outputs error information', () => {
-		assert.include(global.lastResult.output, 'Errors in http://notahost:8090/erroring-1');
-		assert.include(global.lastResult.output, 'net::ERR_NAME_NOT_RESOLVED');
+		assert.include(global.lastResult.output, 'Errors in ./foo/erroring.html');
+		assert.include(global.lastResult.output, 'net::ERR_FILE_NOT_FOUND');
 	});
 
 	it('outputs a total erroring notice', () => {
@@ -45,13 +45,13 @@ describe('pa11y-ci (with multiple erroring URLs)', () => {
 	});
 
 	it('outputs a result notice for each URL', () => {
-		assert.include(global.lastResult.output, 'http://notahost:8090/erroring-1 - Failed to run');
+		assert.include(global.lastResult.output, './foo/erroring.html - Failed to run');
 		assert.include(global.lastResult.output, 'http://localhost:8090/timeout - Failed to run');
 	});
 
 	it('outputs error information', () => {
-		assert.include(global.lastResult.output, 'Errors in http://notahost:8090/erroring-1');
-		assert.include(global.lastResult.output, 'net::ERR_NAME_NOT_RESOLVED');
+		assert.include(global.lastResult.output, 'Errors in ./foo/erroring.html');
+		assert.include(global.lastResult.output, 'net::ERR_FILE_NOT_FOUND');
 		assert.include(global.lastResult.output, 'Errors in http://localhost:8090/timeout');
 		assert.include(global.lastResult.output, 'timed out');
 	});

--- a/test/integration/cli-json.test.js
+++ b/test/integration/cli-json.test.js
@@ -20,9 +20,9 @@ describe('pa11y-ci (with the `--json` flag set)', () => {
 			errors: 1,
 			passes: 1,
 			results: {
-				'http://notahost:8090/erroring-1': [
+				'./foo/erroring.html': [
 					{
-						message: 'net::ERR_NAME_NOT_RESOLVED at http://notahost:8090/erroring-1'
+						message: `net::ERR_FILE_NOT_FOUND at file://${__dirname}/foo/erroring.html`
 					}
 				],
 				'http://localhost:8090/failing-1': [

--- a/test/integration/cli-json.test.js
+++ b/test/integration/cli-json.test.js
@@ -22,7 +22,7 @@ describe('pa11y-ci (with the `--json` flag set)', () => {
 			results: {
 				'./foo/erroring.html': [
 					{
-						message: `net::ERR_FILE_NOT_FOUND at file://${__dirname}/foo/erroring.html`
+						message: `net::ERR_FILE_NOT_FOUND at file://${__dirname}/mock/config/foo/erroring.html`
 					}
 				],
 				'http://localhost:8090/failing-1': [

--- a/test/integration/cli-mixed.test.js
+++ b/test/integration/cli-mixed.test.js
@@ -17,17 +17,17 @@ describe('pa11y-ci (with erroring, failing, and passing URLs)', () => {
 	});
 
 	it('outputs a result notice for each URL', () => {
-		assert.include(global.lastResult.output, 'http://notahost:8090/erroring-1 - Failed to run');
+		assert.include(global.lastResult.output, './foo/erroring.html - Failed to run');
 		assert.include(global.lastResult.output, 'http://localhost:8090/failing-1 - 1 errors');
 		assert.include(global.lastResult.output, 'http://localhost:8090/passing-1 - 0 errors');
 	});
 
 	it('outputs error information', () => {
-		assert.include(global.lastResult.output, 'Errors in http://notahost:8090/erroring-1');
-		assert.include(global.lastResult.output, 'net::ERR_NAME_NOT_RESOLVED');
+		assert.include(global.lastResult.output, 'Errors in ./foo/erroring.html');
+		assert.include(global.lastResult.output, 'net::ERR_FILE_NOT_FOUND');
 		assert.include(global.lastResult.output, 'Errors in http://localhost:8090/failing-1');
 		assert.include(global.lastResult.output, 'html element should have a lang');
-		assert.notInclude(global.lastResult.output, 'Errors in http://notahost:8090/passing-1');
+		assert.notInclude(global.lastResult.output, 'Errors in ./foo/passing-1');
 	});
 
 	it('outputs a total failing notice', () => {

--- a/test/integration/cli-sitemap.test.js
+++ b/test/integration/cli-sitemap.test.js
@@ -27,7 +27,7 @@ describe('pa11y-ci (with a sitemap that can\'t be loaded)', () => {
 	before(() => {
 		return global.cliCall([
 			'--sitemap',
-			'http://notahost:8090/sitemap.xml',
+			'./foo/sitemap.xml',
 			'--config',
 			'empty'
 		]);
@@ -38,7 +38,7 @@ describe('pa11y-ci (with a sitemap that can\'t be loaded)', () => {
 	});
 
 	it('outputs an error message', () => {
-		assert.include(global.lastResult.output, 'http://notahost:8090/sitemap.xml');
+		assert.include(global.lastResult.output, './foo/sitemap.xml');
 		assert.include(global.lastResult.output, 'could not be loaded');
 	});
 

--- a/test/integration/mock/config/erroring-multiple.json
+++ b/test/integration/mock/config/erroring-multiple.json
@@ -1,6 +1,6 @@
 {
 	"urls": [
-		"http://notahost:8090/erroring-1",
+		"./foo/erroring.html",
 		{
 			"url": "http://localhost:8090/timeout",
 			"timeout": 10

--- a/test/integration/mock/config/erroring-single.json
+++ b/test/integration/mock/config/erroring-single.json
@@ -1,5 +1,5 @@
 {
 	"urls": [
-		"http://notahost:8090/erroring-1"
+		"./foo/erroring.html"
 	]
 }

--- a/test/integration/mock/config/mixed.json
+++ b/test/integration/mock/config/mixed.json
@@ -1,6 +1,6 @@
 {
 	"urls": [
-		"http://notahost:8090/erroring-1",
+		"./foo/erroring.html",
 		"http://localhost:8090/failing-1",
 		"http://localhost:8090/passing-1"
 	]


### PR DESCRIPTION
This PR updates the integrations tests that currently rely on DNS failure by removing that dependency and returning the GitHub Actions tests to a passing state (and fixes #132).  It is based on the example already used for the CLI paths test, but passing an invalid file URL, e.g. `./foo/erroring.html`, results in `ERR_FILE_NOT_FOUND` with no external dependencies.