### PR TITLE
Retry launching browser once if it fails the first time

### DIFF
--- a/lib/pa11y-ci.js
+++ b/lib/pa11y-ci.js
@@ -41,7 +41,22 @@ module.exports.defaults = {
 function pa11yCi(urls, options) {
 	return new Promise(async resolve => {
 		// Create a test browser to assign to tests
-		const testBrowser = await puppeteer.launch(options.chromeLaunchConfig);
+		let testBrowser;
+
+		// Issue #128: on specific URLs, Chrome will sometimes fail to load
+		//  the page, or crash during or after loading. This attempts to
+		//  relaunch the browser just once before bailing out, in case Chrome
+		//  crashed at startup. This is just an attempt at mitigating it,
+		//  it won't fix #128 completely or even at all
+		try {
+			testBrowser = await puppeteer.launch(
+				options.chromeLaunchConfig
+			);
+		} catch (error) {
+			testBrowser = await puppeteer.launch(
+				options.chromeLaunchConfig
+			);
+		}
 
 		// Default the passed in options
 		options = defaults({}, options, module.exports.defaults);
@@ -51,7 +66,6 @@ function pa11yCi(urls, options) {
 		// logs from it
 		const log = options.log;
 		delete options.log;
-
 
 		// Create a Pa11y test function and an async queue
 		const taskQueue = queue(testRunner, options.concurrency);


### PR DESCRIPTION
This is a first attempt at fixing #128. It's unlikely to fix the issue completely, or even at all, as the browser will sometimes crash after testing several URLs and we don't have any logic to reopen a browser that has crashed mid-testing.