### PR TITLE
Change concurrency and incognito mode defaults

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,14 +1,22 @@
-# Migration Guide
+# Migration guide
 
 Major versions of Pa11y CI can bring API or compatibility changes. This is a guide to help you make the switch when that happens.
 
-## Migrating From 1.0 To 2.0
+## Migrating from 2.0 to 3.0
 
-### Node.js Support
+### New defaults for `concurrency` and `useIncognitoBrowserContext`
+
+Pa11y CI default concurrency when running tests is now set to 1 instead of the previous 2. This may slow down running of multiple tests but it will help Pa11y CI run more consistently on Continuous Integration environments with limited resources. Users can change this value by setting the [`concurrency` property in the default configuration](https://github.com/pa11y/pa11y-ci#default-configuration).
+
+Pa11y CI now creates a new Incognito browser context by default for each page it tests. This will help pa11y-ci run tests more reliably as the state of a page will not depend on pages tested previous any more. This also means that cookies by default won't be shared between different pages on the same origin. If your tests depend on cookies being shared between different tests, you can use the [`useIncognitoBrowserContext` in the default configuration](https://github.com/pa11y/pa11y-ci#default-configuration) to revert to the previous behaviour.
+
+## Migrating from 1.0 to 2.0
+
+### Node.js support
 
 Pa11y CI 2.0 only supports Node.js v8.0.0 and higher, you'll need to upgrade to be able to use the latest versions of Pa11y CI.
 
-### Changes to Pa11y Test Runner
+### Changes to Pa11y test runner
 
 Pa11y CI now uses Pa11y 5.0 to run its tests, which has introduced numerous changes to the underlying test runner.
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 
 # Pa11y CI
 
-Pa11y CI is a CI-centric accessibility test runner, built using [Pa11y].
+Pa11y CI is an accessibility test runner built using [Pa11y] focused on running on Continuous Integration environments.
 
-CI runs accessibility tests against multiple URLs and reports on any issues. This is best used during automated testing of your application and can act as a gatekeeper to stop a11y issues from making it to live.
+Pa11y CI runs accessibility tests against multiple URLs and reports on any issues. This is best used during automated testing of your application and can act as a gatekeeper to stop a11y issues from making it to live.
 
 [![NPM version][shield-npm]][info-npm]
 [![Node.js version support][shield-node]][info-node]
@@ -96,8 +96,8 @@ You can specify a default set of [pa11y configurations] that should be used for 
 
 Pa11y CI has a few of its own configurations which you can set as well:
 
-  - `concurrency`: The number of tests that should be run in parallel. Defaults to `2`.
-  - `useIncognitoBrowserContext`: Run test with an isolated incognito browser context, stops cookies being shared and modified between tests. Defaults to `false`.
+  - `concurrency`: The number of tests that should be run in parallel. Defaults to `1`.
+  - `useIncognitoBrowserContext`: Run test with an isolated incognito browser context, stops cookies being shared and modified between tests. Defaults to `true`.
 
 ### URL configuration
 

--- a/lib/pa11y-ci.js
+++ b/lib/pa11y-ci.js
@@ -26,13 +26,13 @@ module.exports = pa11yCi;
 // whatever configurations the user passes in from the
 // command line
 module.exports.defaults = {
-	concurrency: 2,
+	concurrency: 1,
 	log: {
 		error: noop,
 		info: noop
 	},
 	wrapWidth: 80,
-	useIncognitoBrowserContext: false
+	useIncognitoBrowserContext: true
 };
 
 // This function does all the setup and actually runs Pa11y

--- a/test/unit/lib/pa11y-ci.test.js
+++ b/test/unit/lib/pa11y-ci.test.js
@@ -45,7 +45,7 @@ describe('lib/pa11y-ci', () => {
 		});
 
 		it('has a `concurrency` property', () => {
-			assert.strictEqual(defaults.concurrency, 2);
+			assert.strictEqual(defaults.concurrency, 1);
 		});
 
 		it('has a `log` property', () => {
@@ -65,7 +65,7 @@ describe('lib/pa11y-ci', () => {
 		});
 
 		it('has a `useIncognitoBrowserContext` property', () => {
-			assert.strictEqual(defaults.useIncognitoBrowserContext, false);
+			assert.strictEqual(defaults.useIncognitoBrowserContext, true);
 		});
 	});
 


### PR DESCRIPTION
This changes the default for concurrency to 1 (from the previous 2) and the default for useIncognitoBrowserContext to true in order to improve the reliability of pa11y-ci with the default settings.

It also updates the Migration guide to explain these changes.

Closes #147.