### PR TITLE
Add missing await for closing incognito browser context.

### DIFF
--- a/lib/pa11y-ci.js
+++ b/lib/pa11y-ci.js
@@ -132,7 +132,7 @@ function pa11yCi(urls, options) {
 				report.results[url] = [error];
 			} finally {
 				if (config.useIncognitoBrowserContext) {
-					config.browser.close();
+					await config.browser.close();
 				}
 			}
 		}


### PR DESCRIPTION
Add missing `await` for closing incognito browser context. Errors have been seen running custom reporters with async functions, as noted in https://github.com/pa11y/pa11y-ci/issues/168#issuecomment-990562886, with the stack trace pointing to this line. The `browserContext.close` function is async, so without the `await` there appears to be timing issues between the [`browserContext.close`](https://github.com/pa11y/pa11y-ci/blob/efad30255318be167c337b6b1b255ad691c0e8b4/lib/pa11y-ci.js#L135) and parent [`browser.close`](https://github.com/pa11y/pa11y-ci/blob/efad30255318be167c337b6b1b255ad691c0e8b4/lib/pa11y-ci.js#L144) (which are likely masked in other cases by pa11y-ci completing and exiting the process).

This change did resolve at least the reporter problem noted in https://github.com/pa11y/pa11y-ci/issues/168 (as did running with `"useIncognitoBrowserContext": false` as a workaround). The build-in reporters (`cli`/`html`) are only synchronous code and don't appear to cause it.

I haven't seen this with other execution as noted in https://github.com/pa11y/pa11y-ci/issues/168, so not clear if it will resolve the other issues, but those errors do also point to this line of code.