### PR TITLE
Update integration tests to support all platforms, including Windows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,26 +9,34 @@ on:
       - master
   pull_request:
     branches: # Run actions when a PR is pushed based on one of these branches
-      - master
+      - '**'
 
 jobs:
   checkout_and_test:
-    runs-on: ubuntu-latest
+    name: Node v${{ matrix.node }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+        node: [12, 14, 16]
         include:
-          - node-version: 12.x
+          - os: ubuntu-latest
+            node: 12
             lint: true # Linter is run only once to shorten the total build time
-          - node-version: 14.x
-          - node-version: 16.x
 
     steps:
+      - name: Set git config
+        shell: bash
+        run: |
+          git config --global core.autocrlf false
+        if: runner.os == 'Windows'
       - name: Checkout code from ${{ github.repository }}
-        uses: actions/checkout@v2
-      - name: Setup node
-        uses: actions/setup-node@v2
+        uses: actions/checkout@v3
+      - name: Setup node ${{ matrix.node }}
+        uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: ${{ matrix.node }}
       - name: Install dependencies
         run: npm ci
       - name: Run linter

--- a/test/integration/cli-json.test.js
+++ b/test/integration/cli-json.test.js
@@ -1,6 +1,7 @@
 /* eslint max-len: 'off' */
 'use strict';
 
+const path = require('path');
 const assert = require('proclaim');
 
 describe('pa11y-ci (with the `--json` flag set)', () => {
@@ -15,6 +16,7 @@ describe('pa11y-ci (with the `--json` flag set)', () => {
 
 	it('outputs the results as JSON', () => {
 		const outputData = JSON.parse(global.lastResult.output);
+		const filePath = path.resolve(__dirname, 'mock/config/foo/erroring.html');
 		assert.deepEqual(outputData, {
 			total: 3,
 			errors: 1,
@@ -22,7 +24,7 @@ describe('pa11y-ci (with the `--json` flag set)', () => {
 			results: {
 				'./foo/erroring.html': [
 					{
-						message: `net::ERR_FILE_NOT_FOUND at file://${__dirname}/mock/config/foo/erroring.html`
+						message: `net::ERR_FILE_NOT_FOUND at file://${filePath}`
 					}
 				],
 				'http://localhost:8090/failing-1': [

--- a/test/integration/mock/website/index.js
+++ b/test/integration/mock/website/index.js
@@ -2,6 +2,7 @@
 
 const fs = require('fs');
 const http = require('http');
+const path = require('path');
 const parseUrl = require('url').parse;
 
 module.exports = startWebsite;
@@ -11,13 +12,13 @@ function startWebsite(port, done) {
 	const server = http.createServer((request, response) => {
 
 		const urlPath = parseUrl(request.url).pathname;
-		const viewPath = `${__dirname}/html${urlPath}.html`;
+		const viewPath = path.join(__dirname, 'html', `${urlPath}.html`);
 
 		if (urlPath.includes('.xml')) {
 			response.writeHead(200, {
 				'Content-Type': 'text/xml'
 			});
-			return response.end(fs.readFileSync(`${__dirname}/${urlPath}`, 'utf-8'));
+			return response.end(fs.readFileSync(path.join(__dirname, urlPath), 'utf-8'));
 		}
 
 		try {

--- a/test/integration/setup.test.js
+++ b/test/integration/setup.test.js
@@ -15,9 +15,9 @@ before(done => {
 	});
 });
 
-function cliCall(cliArguments) {
+function cliCall(cliArguments = []) {
 
-	const command = path.resolve(__dirname, '../../bin/pa11y-ci.js');
+	const binFile = path.resolve(__dirname, '../../bin/pa11y-ci.js');
 	const result = {
 		output: '',
 		stdout: '',
@@ -26,7 +26,7 @@ function cliCall(cliArguments) {
 	};
 
 	return new Promise(resolve => {
-		const child = spawn(command, cliArguments || [], {
+		const child = spawn('node', [binFile, ...cliArguments], {
 			cwd: path.join(__dirname, 'mock/config'),
 			env: process.env
 		});


### PR DESCRIPTION
This PR updates the integration tests to support all platforms, including Windows. The current integration tests fail on Windows for two reasons:

1. The `startWebsite` function and JSON output tests rely on POSIX-style paths, so encounter errors when simply concatenated with Windows paths. The `path.resolve` or `path.join` functions are used instead.
2. The `cliCall` function that executes the tests assumes the `bin` file is executable, which works in *nix systems, but is not true in Windows since it ignores the shebang. This function is updated to explicitly run the `node` command against the `bin` file.


This also adds Windows and Mac test cases to the GitHub Actions, matching https://github.com/pa11y/pa11y/pull/640.