### PR TITLE
Add custom default headers to sitemap query

### DIFF
--- a/bin/pa11y-ci.js
+++ b/bin/pa11y-ci.js
@@ -223,7 +223,7 @@ function loadSitemapIntoConfig(program, initialConfig) {
 
 	function getUrlsFromSitemap(sitemapUrl, config) {
 		return Promise.resolve()
-			.then(() => fetch(sitemapUrl))
+			.then(() => fetch(sitemapUrl, {headers: config.defaults.headers || {}}))
 			.then(response => response.text())
 			.then(body => {
 				const $ = cheerio.load(body, {xmlMode: true});


### PR DESCRIPTION
Add any default headers provided in `.pallyci.js` to the sitemap query.

Particularly useful if you're using `headers` to set secure cookies in order to pass authentication checks necessary to access the sitemap (e.g. secure test environments).