### PR TITLE
Upgrade async library due to CVE-2021-43138

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -560,9 +560,9 @@
       "dev": true
     },
     "async": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
       "requires": {
         "lodash": "^4.17.14"
       }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "node": ">=12"
   },
   "dependencies": {
-    "async": "~2.6.3",
+    "async": "~2.6.4",
     "cheerio": "~1.0.0-rc.10",
     "commander": "~6.2.1",
     "globby": "~6.1.0",


### PR DESCRIPTION
There is a security advisory to avoid using async 2.6.3 and below, see https://avd.aquasec.com/nvd/2021/cve-2021-43138/

```
+------------------+------------------+----------+-------------------+---------------+---------------------------------------+
|     LIBRARY      | VULNERABILITY ID | SEVERITY | INSTALLED VERSION | FIXED VERSION |                 TITLE                 |
+------------------+------------------+----------+-------------------+---------------+---------------------------------------+
| async            | CVE-2021-43138   | HIGH     | 2.6.3             | 2.6.4, 3.2.2  | Prototype Pollution in async          |
|                  |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-43138 |
+------------------+------------------+----------+-------------------+---------------+---------------------------------------+
```