### PR TITLE
fix(docs): add concurrency proper definition of execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ You can specify a default set of [pa11y configurations] that should be used for 
 
 Pa11y CI has a few of its own configurations which you can set as well:
 
-* `concurrency`: The number of tests that should be run in concurrently. Defaults to `1`.
+* `concurrency`: The number of tests that should be run concurrently. Defaults to `1`.
 * `useIncognitoBrowserContext`: Run test with an isolated incognito browser context, stops cookies being shared and modified between tests. Defaults to `true`.
 
 ### URL configuration

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ You can specify a default set of [pa11y configurations] that should be used for 
 
 Pa11y CI has a few of its own configurations which you can set as well:
 
-* `concurrency`: The number of tests that should be run in parallel. Defaults to `1`.
+* `concurrency`: The number of tests that should be run in concurrently. Defaults to `1`.
 * `useIncognitoBrowserContext`: Run test with an isolated incognito browser context, stops cookies being shared and modified between tests. Defaults to `true`.
 
 ### URL configuration


### PR DESCRIPTION
* fix docs describing concurrency since parallel processing is not the same and this library does not perform actions multi-threaded.