### PR TITLE
refactor: replaced badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Pa11y CI runs accessibility tests against multiple URLs and reports on any issue
 [![NPM version][shield-npm]][info-npm]
 [![Node.js version support][shield-node]][info-node]
 [![Build status][shield-build]][info-build]
-[![Dependencies][shield-dependencies]][info-dependencies]
+[![Dependencies][shield-vulnerabilities]][info-vulnerabilities]
 [![LGPL-3.0-only licensed][shield-license]][info-license]
 
 ---
@@ -413,12 +413,12 @@ Copyright &copy; 2016–2021, Team Pa11y
 [sidekick-proposal]: https://github.com/pa11y/sidekick/blob/master/PROPOSAL.md
 [twitter]: https://twitter.com/pa11yorg
 
-[info-dependencies]: https://gemnasium.com/pa11y/pa11y-ci
+[info-vulnerabilities]: https://snyk.io/test/github/mfranzke/loading-attribute-polyfill-with-serviceworker?targetFile=package.json
 [info-license]: LICENSE
 [info-node]: package.json
 [info-npm]: https://www.npmjs.com/package/pa11y-ci
 [info-build]: https://travis-ci.org/pa11y/pa11y-ci
-[shield-dependencies]: https://img.shields.io/gemnasium/pa11y/pa11y-ci.svg
+[shield-vulnerabilities]: https://snyk.io/test/github/mfranzke/loading-attribute-polyfill-with-serviceworker/badge.svg?targetFile=package.json
 [shield-license]: https://img.shields.io/badge/license-LGPL--3.0--only-blue.svg
 [shield-node]: https://img.shields.io/badge/node.js%20support-8-brightgreen.svg
 [shield-npm]: https://img.shields.io/npm/v/pa11y-ci.svg


### PR DESCRIPTION
[gemnasium has been integrated into GitLab](https://about.gitlab.com/press/releases/2018-01-30-gemnasium-acquisition.html) and therefor most likely doesn't provide the gemnasium.com service any more. So I'd like to suggest to replace it by https://snyk.io/ for vulnerability scanning (not exactly the same, but similar; I'm not aware of an open source service that would provide the exact same functionality).