### PR TITLE
Version `3.1.0`

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ on:
         type: boolean
 
 jobs:
-  build:
+  publish:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@
 * Upgrade `pa11y` to `^6.2.3` from `~6.1.0`
   * Switch to caret for `pa11y` to allow `pa11y` to be upgraded to a more recent compatible version upon install (thanks @aarongoldenthal)
 * [Fix licensing identifier](https://github.com/pa11y/pa11y-ci/pull/123) (thanks @LorenzoAncora)
-* Update documentation to indicate support for more recent stable versions of operating systems and Node.js
+* Update documentation:
+  * Indicate support for more recent stable versions of operating systems and Node.js
+  * Add [JS config file example](https://github.com/pa11y/pa11y-ci/pull/197) (thanks @aarongoldenthal)
 
 ### New contributors
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 
 ### Full changelog
 
-https://github.com/pa11y/pa11y-ci/compare/3.0.1...3.1.0
+[3.0.1...3.1.0](https://github.com/pa11y/pa11y-ci/compare/3.0.1...3.1.0)
 
 ## 3.0.1 (2021-12-20)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,27 @@
 
 ## 3.1.0 (2023-11-14)
 
-* Placeholder
+### Changes
+
+* Upgrade `pa11y` to `^6.2.3` from `~6.1.0`
+  * Switch to caret for `pa11y` to allow `pa11y` to be upgraded to a more recent compatible version upon install (thanks @aarongoldenthal)
+* [Fix licensing identifier](https://github.com/pa11y/pa11y-ci/pull/123) (thanks @LorenzoAncora)
+* Update documentation to indicate support for more recent stable versions of operating systems and Node.js
+
+### New contributors
+
+* @LorenzoAncora [made their first contribution](https://github.com/pa11y/pa11y-ci/pull/123)
+* @danyalaytekin [made their first contribution](https://github.com/pa11y/pa11y-ci/pull/213)
+
+### Behind the scenes
+
+* Expand testing to:
+  * [test Windows and macOS](https://github.com/pa11y/pa11y-ci/pull/177) alongside Linux (thanks again @aarongoldenthal)
+  * test with Node.js 18 and 20, alongside 12, 14, 16
+
+### Full changelog
+
+https://github.com/pa11y/pa11y-ci/compare/3.0.1...3.1.0
 
 ## 3.0.1 (2021-12-20)
 

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ pa11y-ci --sitemap https://pa11y.org/sitemap.xml
 
 Pa11y will be run against the text content of each `<loc/>` in the sitemap's XML.
 
-> NOTE
+> [!NOTE]
 > Providing a sitemap will cause the `urls` property in your JSON config to be ignored.
 
 #### Transforming URLs retrieved from a sitemap before testing
@@ -199,7 +199,7 @@ You can use multiple reporters by setting them on the `defaults.reporters` array
 }
 ```
 
-> NOTE
+> [!NOTE]
 > If the `--reporter` flag is provided on the command line, all appearances of `reporters` in the config file will be overridden.
 
 ### Reporter options

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ npm install -g pa11y-ci
 ```
 
 ```console
-$ npx pa11y-ci --help
+$ pa11y-ci --help
 
 Usage: pa11y-ci [options] <paths>
 

--- a/README.md
+++ b/README.md
@@ -434,6 +434,6 @@ Copyright &copy; 2016-2023, Team Pa11y and contributors
 [info-build]: https://github.com/pa11y/pa11y-ci/actions/workflows/tests.yml
 
 [shield-license]: https://img.shields.io/badge/license-LGPL--3.0--only-blue.svg
-[shield-node]: https://img.shields.io/badge/node.js%20support-8-brightgreen.svg
+[shield-node]: https://img.shields.io/node/v/pa11y-ci.svg
 [shield-npm]: https://img.shields.io/npm/v/pa11y-ci.svg
 [shield-build]: https://github.com/pa11y/pa11y-ci/actions/workflows/tests.yml/badge.svg

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pa11y-ci",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pa11y-ci",
-      "version": "3.0.1",
+      "version": "3.1.0",
       "license": "LGPL-3.0-only",
       "dependencies": {
         "async": "~2.6.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pa11y-ci",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "description": "Pa11y CI is a CI-centric accessibility test runner, built using Pa11y",
   "keywords": [],
   "author": "Team Pa11y",


### PR DESCRIPTION
## Changes

- Everything in [the changelog entry for `3.1.0`](https://github.com/pa11y/pa11y-ci/pull/226/files?short_path=06572a9#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed)
    - here's the full diff link for now, since the one in the changelog won't work until the tag `3.1.0` is created: https://github.com/pa11y/pa11y-ci/compare/3.0.1...version-3.1
- Plus items that do not affect the user:
    - rename publishing job id to `publish` from `build`
    - several dependency updates (minor or patch) from Dependabot

## Also

- resolves #176