### PR TITLE
Ignore config urls when using sitemap

### DIFF
--- a/bin/pa11y-ci.js
+++ b/bin/pa11y-ci.js
@@ -72,6 +72,7 @@ Promise.resolve()
 	.then(config => {
 		// Load a sitemap based on the `--sitemap` flag
 		if (commander.sitemap) {
+			config.urls = [];
 			return loadSitemapIntoConfig(commander, config);
 		}
 		return config;
@@ -209,6 +210,7 @@ function defaultConfig(config) {
 // Load a sitemap from a remote URL, parse out the
 // URLs, and add them to an existing config object
 function loadSitemapIntoConfig(program, initialConfig) {
+	console.log('config', initialConfig);
 	const sitemapFind = (
 		program.sitemapFind ?
 			new RegExp(program.sitemapFind, 'gi') :

--- a/test/integration/cli-sitemap.test.js
+++ b/test/integration/cli-sitemap.test.js
@@ -107,3 +107,24 @@ describe('pa11y-ci (with a sitemap being sitemapindex)', () => {
 	});
 
 });
+
+describe('pa11y-ci (with a sitemap being sitemapindex) and config. should ignore config urls', () => {
+
+	before(() => {
+		return global.cliCall([
+			'--sitemap',
+			'http://localhost:8090/sitemapindex.xml',
+			'--config',
+			'extension-json'
+		]);
+	});
+
+	it('loads the expected urls from multiple sitemaps', () => {
+		assert.notInclude(global.lastResult.output, 'http://localhost:8090/config-extension-json');
+		assert.include(global.lastResult.output, 'http://localhost:8090/passing-1');
+		assert.include(global.lastResult.output, 'http://localhost:8090/failing-1');
+		assert.include(global.lastResult.output, 'http://localhost:8090/excluded');
+		assert.include(global.lastResult.output, 'http://localhost:8090/passing-2');
+	});
+
+});


### PR DESCRIPTION
[Bug report](https://github.com/pa11y/pa11y-ci/issues/229) about the problem. 

Readme states that `Providing a sitemap will cause the urls property in your JSON config to be ignored.` but the code doesn't work as expected.

I have prepared a change that sets config urls to empty array when sitemap is provided. Change includes also a test case that was missing before.