### PR TITLE
[WIP, draft] Improve Docker support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,3 +35,14 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - run: npm ci
       - run: npm test
+
+  test-docker:
+    name: test on base Docker image 'node:${{ matrix.node-version }}-alpine'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        node-version: [18, 20]
+    steps:
+      - uses: actions/checkout@v4
+      - run: docker build . --build-arg BASE_IMAGE=node:${{ matrix.node-version }}-alpine -t pa11y-ci-on-node-${{ matrix.node-version }}-alpine

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+ARG BASE_IMAGE=node:20-alpine
+FROM $BASE_IMAGE
+
+# Install Chromium
+RUN apk add --no-cache \
+	chromium
+
+# Install Chromium's dependencies
+RUN apk add --no-cache \
+	ca-certificates \
+	freetype \
+	harfbuzz \
+	nss \
+	ttf-freefont
+
+# Switch user from 'root' to 'node' (inherited from node:alpine)
+USER node
+
+# Let's install global dependencies somewhere visitable by user 'node'
+ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
+ENV PATH=$PATH:/home/node/.npm-global/bin
+
+# Avoid downloading Chromium again
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
+
+# Install Pa11y CI and our config into the container
+RUN npm install --global pa11y-ci
+# COPY ./config.json /usr/config.json
+
+ENTRYPOINT ["pa11y-ci", "--config", "/usr/config.json"]

--- a/README.md
+++ b/README.md
@@ -342,7 +342,7 @@ module.exports = function (options) {
 
 ### Docker
 
-If you want to run `pa11y-ci` in a Docker container then you can use the [`buildkite/puppeteer`](https://github.com/buildkite/docker-puppeteer) image as this installs Chrome and all the required libs to run headless chrome on Linux.
+We could make use of [Puppeteer's official Docker image](https://pptr.dev/guides/docker) to run Pa11y CI inside a container. This would require the `SYS_ADMIN` capability, which increases the security surface of a container. We can avoid this by installing Puppeteer and Chromium afresh at the cost of a slightly more complex Dockerfile. This will also reduce the size of Puppeteer-related layers from over 2GB to ~750MB.
 
 You will need a `config.json` that sets the `--no-sandbox` Chromium launch arguments:
 

--- a/README.md
+++ b/README.md
@@ -391,7 +391,7 @@ We could make use of [Puppeteer's official Docker image](https://pptr.dev/guides
     ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
 
     # Install Pa11y CI and our config into the container
-    RUN npm install --global --unsafe-perm pa11y-ci
+    RUN npm install --global pa11y-ci
     COPY ./config.json /usr/config.json
 
     ENTRYPOINT ["pa11y-ci", "--config", "/usr/config.json"]

--- a/README.md
+++ b/README.md
@@ -344,7 +344,7 @@ module.exports = function (options) {
 
 We could use [Puppeteer's official Docker image](https://pptr.dev/guides/docker) as the base of a Pa11y CI image. However, this would require the `SYS_ADMIN` capability, which will increase the security surface of the container. We can avoid this by installing Puppeteer and Chromium afresh at the cost of a more complex Dockerfile. This will also reduce the size of the Puppeteer-related layers from over 2GB to ~750MB.
 
-1. Create a `Dockerfile`. Install `pa11y-ci` within and expose `config.json`.
+1. Create a `Dockerfile`. Install `pa11y-ci` within and supply `config.json`.
 
     ```Dockerfile
     FROM node:20-alpine

--- a/README.md
+++ b/README.md
@@ -342,25 +342,7 @@ module.exports = function (options) {
 
 ### Docker
 
-We could make use of [Puppeteer's official Docker image](https://pptr.dev/guides/docker) to run Pa11y CI inside a container. This would require the `SYS_ADMIN` capability, which increases the security surface of a container. We can avoid this by installing Puppeteer and Chromium afresh at the cost of a slightly more complex Dockerfile. This will also reduce the size of Puppeteer-related layers from over 2GB to ~750MB.
-
-1. Create a `./config.json`. Use the `--no-sandbox` argument for Chromium.
-
-    ```json
-    {
-        "defaults": {
-            "chromeLaunchConfig": {
-                "args": [
-                    "--no-sandbox"
-                ]
-            }
-        },
-        "urls": [
-            "https://pa11y.org/",
-            "https://pa11y.org/contributing"
-        ]
-    }
-    ```
+We could use [Puppeteer's official Docker image](https://pptr.dev/guides/docker) as the base of a Pa11y CI image. However, this would require the `SYS_ADMIN` capability, which will increase the security surface of the container. We can avoid this by installing Puppeteer and Chromium afresh at the cost of a more complex Dockerfile. This will also reduce the size of the Puppeteer-related layers from over 2GB to ~750MB.
 
 1. Create a `Dockerfile`. Install `pa11y-ci` within and expose `config.json`.
 
@@ -397,13 +379,33 @@ We could make use of [Puppeteer's official Docker image](https://pptr.dev/guides
     ENTRYPOINT ["pa11y-ci", "--config", "/usr/config.json"]
     ```
 
-1. Build and run the image.
+1. Create a `./config.json`. Use the `--no-sandbox` argument for Chromium.
 
-    ```shell
+    ```json
+    {
+        "defaults": {
+            "chromeLaunchConfig": {
+                "args": [
+                    "--no-sandbox"
+                ]
+            }
+        },
+        "urls": [
+            "https://pa11y.org/",
+            "https://pa11y.org/contributing"
+        ]
+    }
+    ```
+
+1. Build our configured image.
+
+    ```sh
     docker build -t pa11y-ci-for-some-project .
     ```
 
-    ```shell
+1. Create and run a container from the image.
+
+    ```sh
     docker run pa11y-ci-for-some-project
     ```
 


### PR DESCRIPTION
Description to follow.

## To do

- [ ] Decide whether Actions should only verify build, or both build and test
- [ ] Decide how to build the PR's version of `pa11y-ci`
    - pack in place then install globally?
    - pack outside, expose, install globally inside? 
    - publish to GitHub's own artifact registry during earlier stage, then pull down?
- [ ] Folder structure for inputs and debris