### PR TITLE
Add support for `.cjs` extension

### DIFF
--- a/bin/pa11y-ci.js
+++ b/bin/pa11y-ci.js
@@ -127,6 +127,9 @@ function loadConfig(configPath) {
 				config = loadLocalConfigWithJs(configPath);
 			}
 			if (!config) {
+				config = loadLocalConfigWithCjs(configPath);
+			}
+			if (!config) {
 				config = loadLocalConfigWithJson(configPath);
 			}
 			if (options.config && !config) {
@@ -153,8 +156,8 @@ function resolveConfigPath(configPath) {
 	if (!path.isAbsolute(configPath)) {
 		configPath = path.join(process.cwd(), configPath);
 	}
-	if (/\.js(on)?$/.test(configPath)) {
-		configPath = configPath.replace(/\.js(on)?$/, '');
+	if (/\.(c?js|json)$/.test(configPath)) {
+		configPath = configPath.replace(/\.(c?js|json)$/, '');
 	}
 	return configPath;
 }
@@ -175,6 +178,17 @@ function loadLocalConfigUnmodified(configPath) {
 function loadLocalConfigWithJs(configPath) {
 	try {
 		return require(`${configPath}.js`);
+	} catch (error) {
+		if (error.code !== 'MODULE_NOT_FOUND') {
+			throw error;
+		}
+	}
+}
+
+// Load the config file but adding a .cjs extension
+function loadLocalConfigWithCjs(configPath) {
+	try {
+		return require(`${configPath}.cjs`);
 	} catch (error) {
 		if (error.code !== 'MODULE_NOT_FOUND') {
 			throw error;


### PR DESCRIPTION
Hey there,

I just added a small change to add support for `.cjs` extensions. I think for most modern Javascript projects we use ES6 modules instead for CommonJS, so even for frameworks such as SvelteKit (what we use in our company) or Next.js the default setting for `.js` files is `module` (defined in `package.json`). In such cases, we usually use `.cjs` extension for CommonJS files.

I was unable to run `pa11y-ci` with a custom config other than a JSON file because it was not allowing me to use a `.js` file and the `.cjs` extension was not recognized.

With the provided change, I can run `pa11y` in our project.