### PR TITLE
Fix test script quoting to run properly on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,9 +52,9 @@
   "scripts": {
     "lint": "eslint .",
     "verify-coverage": "nyc check-coverage --lines 90 --functions 90 --branches 90",
-    "test-unit": "mocha --file test/unit/setup.test.js \"test/unit/**/*.test.js\"",
-    "test-coverage": "nyc --reporter=text --reporter=html mocha --file test/unit/setup.test.js \"test/unit/**/*.test.js\"",
-    "test-integration": "mocha --file test/integration/setup.test.js \"test/integration/**/*.test.js\" test/integration/teardown.test.js --timeout 20000 --slow 5000",
+    "test-unit": "mocha --file test/unit/setup.test.js \"test/unit/**/*.test.js\" --fail-zero",
+    "test-coverage": "nyc --reporter=text --reporter=html mocha --file test/unit/setup.test.js \"test/unit/**/*.test.js\" --fail-zero",
+    "test-integration": "mocha --file test/integration/setup.test.js \"test/integration/**/*.test.js\" test/integration/teardown.test.js --timeout 20000 --slow 5000 --fail-zero",
     "test": "npm run test-coverage && npm run verify-coverage && npm run test-integration"
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -52,9 +52,9 @@
   "scripts": {
     "lint": "eslint .",
     "verify-coverage": "nyc check-coverage --lines 90 --functions 90 --branches 90",
-    "test-unit": "mocha --file test/unit/setup.test.js 'test/unit/**/*.test.js' --recursive",
-    "test-coverage": "nyc --reporter=text --reporter=html mocha --file test/unit/setup.test.js 'test/unit/**/*.test.js' --recursive",
-    "test-integration": "mocha --file test/integration/setup.test.js 'test/integration/**/*.test.js' test/integration/teardown.test.js --recursive --timeout 20000 --slow 5000",
+    "test-unit": "mocha --file test/unit/setup.test.js test/unit/**/*.test.js --recursive",
+    "test-coverage": "nyc --reporter=text --reporter=html mocha --file test/unit/setup.test.js test/unit/**/*.test.js --recursive",
+    "test-integration": "mocha --file test/integration/setup.test.js test/integration/**/*.test.js test/integration/teardown.test.js --recursive --timeout 20000 --slow 5000",
     "test": "npm run test-coverage && npm run verify-coverage && npm run test-integration"
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -52,9 +52,9 @@
   "scripts": {
     "lint": "eslint .",
     "verify-coverage": "nyc check-coverage --lines 90 --functions 90 --branches 90",
-    "test-unit": "mocha --file test/unit/setup.test.js test/unit/**/*.test.js --recursive",
-    "test-coverage": "nyc --reporter=text --reporter=html mocha --file test/unit/setup.test.js test/unit/**/*.test.js --recursive",
-    "test-integration": "mocha --file test/integration/setup.test.js test/integration/**/*.test.js test/integration/teardown.test.js --recursive --timeout 20000 --slow 5000",
+    "test-unit": "mocha --file test/unit/setup.test.js \"test/unit/**/*.test.js\"",
+    "test-coverage": "nyc --reporter=text --reporter=html mocha --file test/unit/setup.test.js \"test/unit/**/*.test.js\"",
+    "test-integration": "mocha --file test/integration/setup.test.js \"test/integration/**/*.test.js\" test/integration/teardown.test.js --timeout 20000 --slow 5000",
     "test": "npm run test-coverage && npm run verify-coverage && npm run test-integration"
   },
   "files": [


### PR DESCRIPTION
The current test scripts single quote the test pattern glob, which runs properly in Linux and macOS, but on Windows it results in no tests found. This then passes since no tests failed, as seen in the following log from [here](https://github.com/pa11y/pa11y-ci/actions/runs/16334292626/job/46143256139).

<details>
<summary>Actions Log</summary>

```
Run npm test

> pa11y-ci@3.1.0 test
> npm run test-coverage && npm run verify-coverage && npm run test-integration

> pa11y-ci@3.1.0 test-coverage
> nyc --reporter=text --reporter=html mocha --file test/unit/setup.test.js 'test/unit/**/*.test.js' --recursive

Warning: Cannot find any files matching pattern "'test/unit/**/*.test.js'"

  0 passing (1ms)

----------|---------|----------|---------|---------|-------------------
File      | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
----------|---------|----------|---------|---------|-------------------
All files |       0 |        0 |       0 |       0 |                   
----------|---------|----------|---------|---------|-------------------

> pa11y-ci@3.1.0 verify-coverage
> nyc check-coverage --lines 90 --functions 90 --branches 90

Warning: Cannot find any files matching pattern "'test/integration/**/*.test.js'"
> pa11y-ci@3.1.0 test-integration
> mocha --file test/integration/setup.test.js 'test/integration/**/*.test.js' test/integration/teardown.test.js --recursive --timeout 20000 --slow 5000

  0 passing (0ms)
```

</details>

This traces back to the original conversion from make to npm scripts in https://github.com/pa11y/pa11y-ci/commit/40ba01a03fd214e94c2a37f5d53c1cf527fff987, with the note "quote globs in scripts to avoid missingsubdirectories". On Linux/macOS without the quotes, or with double quotes, the `tests/unit/lib/reporters/*` tests are not run, although on Windows the tests all run in those cases. Mocha was updated in #256 (from 10.3.0 to 11.1.0), and this appears to have been missed (tests run as expected in the previous commit).

Keeping the globs, double quoted, but without the `--recursive` flag seems to work on all platforms. I also added the `--fail-zero` flag, which will fail if no tests are found.

This appears to be an instance of https://github.com/mochajs/mocha/issues/4186.