### PR TITLE
Add Dependabot configuration file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: 'npm'
+    allow:
+      - dependency-type: 'production'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    labels:
+      - 'dependencies'
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'daily'
+    labels:
+      - 'dependencies'


### PR DESCRIPTION
This PR adds a `dependabot.yml` configuration file, which matches the Pa11y configuration added in https://github.com/pa11y/pa11y/pull/718. This config checks weekly for any NPM production dependencies and daily for GitHub actions.