### PR TITLE
Set explicit read permissions for tests workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,6 +4,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR limits the permissions of the GITHUB_TOKEN for the test/lint Action Workflow to read only. The default permissions for repositories created before February 2023, like this one, is read-write. This resolves two issues identified by CodeQL ([here](https://github.com/pa11y/pa11y-ci/security/code-scanning/5) and [here](https://github.com/pa11y/pa11y-ci/security/code-scanning/6) for those with the appropriate permissions).
