### PR TITLE
updates engines field to required minimum version

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "bugs": "https://github.com/pa11y/pa11y-ci/issues",
   "license": "LGPL-3.0-only",
   "engines": {
-    "node": ">=20.18.1"
+    "node": ">=20.18.1 <25"
   },
   "dependencies": {
     "async": "~3.2.6",


### PR DESCRIPTION
```
$ nvm use 20
Now using node v20.17.0 (npm v10.8.2)
$ npm ci
npm warn EBADENGINE Unsupported engine {
npm warn EBADENGINE   package: 'cheerio@1.1.2',
npm warn EBADENGINE   required: { node: '>=20.18.1' },
npm warn EBADENGINE   current: { node: 'v20.17.0', npm: '10.8.2' }
npm warn EBADENGINE }
npm warn EBADENGINE Unsupported engine {
npm warn EBADENGINE   package: 'undici@7.12.0',
npm warn EBADENGINE   required: { node: '>=20.18.1' },
npm warn EBADENGINE   current: { node: 'v20.17.0', npm: '10.8.2' }
npm warn EBADENGINE }
...
```