### PR TITLE
Upgrade commander to latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "async": "~3.2.6",
         "cheerio": "~1.0.0",
-        "commander": "~14.0.0",
+        "commander": "~14.0.1",
         "globby": "~6.1.0",
         "kleur": "~4.1.5",
         "lodash": "~4.17.21",
@@ -1395,9 +1395,9 @@
       "license": "MIT"
     },
     "node_modules/commander": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.0.tgz",
-      "integrity": "sha512-2uM9rYjPvyq39NwLRqaiLtWHyDC1FvryJDa2ATTVims5YAS4PupsEQsDvP14FqhFr0P49CYDugi59xaxJlTXRA==",
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.1.tgz",
+      "integrity": "sha512-2JkV3gUZUVrbNA+1sjBOYLsMZ5cEEl8GTFP2a4AVz5hvasAMCQ1D2l2le/cX+pV4N6ZU17zjUahLpIXRrnWL8A==",
       "license": "MIT",
       "engines": {
         "node": ">=20"

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "async": "~3.2.6",
     "cheerio": "~1.0.0",
-    "commander": "~14.0.0",
+    "commander": "~14.0.1",
     "globby": "~6.1.0",
     "kleur": "~4.1.5",
     "lodash": "~4.17.21",


### PR DESCRIPTION
Pa11y has been upgraded to this version too, so NPM will be able to dedup the package when installing instead of having to install both v13 and v14 of commander.