### PR TITLE
Use OIDC for publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,11 +20,9 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           registry-url: https://registry.npmjs.org
 
-      - name: Update npm for OIDC
-        run: npm install -g npm@latest
       - run: npm ci
 
       - name: Publish package


### PR DESCRIPTION
Following guidelines:

- https://docs.npmjs.com/trusted-publishers
- https://github.blog/changelog/2025-07-31-npm-trusted-publishing-with-oidc-is-generally-available/
