### PR TITLE
fix: replace kleur with Node.js built-in util.styleText

### DIFF
--- a/lib/reporters/cli.js
+++ b/lib/reporters/cli.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const {cyan, green, grey, red, underline} = require('kleur');
+const {styleText} = require('util');
 const wordwrap = require('wordwrap');
 const defaults = require('lodash/defaults');
 const defaultCfg = require('../helpers/defaults');
@@ -30,7 +30,7 @@ module.exports = function cliReporter(options = {}, config = {}) {
 
 	return {
 		beforeAll(urls) {
-			log.info(cyan(underline(`Running Pa11y on ${urls.length} URLs:`)));
+			log.info(styleText(['cyan', 'underline'], `Running Pa11y on ${urls.length} URLs:`));
 		},
 
 		results(testResults, reportConfig) {
@@ -38,14 +38,14 @@ module.exports = function cliReporter(options = {}, config = {}) {
 				testResults.issues.length <= reportConfig.threshold :
 				false;
 
-			let message = ` ${cyan('>')} ${testResults.pageUrl} - `;
+			let message = ` ${styleText('cyan', '>')} ${testResults.pageUrl} - `;
 			if (testResults.issues.length && !withinThreshold) {
-				message += red(`${testResults.issues.length} errors`);
+				message += styleText('red', `${testResults.issues.length} errors`);
 				log.error(message);
 			} else {
-				message += green(`${testResults.issues.length} errors`);
+				message += styleText('green', `${testResults.issues.length} errors`);
 				if (withinThreshold) {
-					message += green(
+					message += styleText('green',
 						` (within threshold of ${reportConfig.threshold})`
 					);
 				}
@@ -54,23 +54,23 @@ module.exports = function cliReporter(options = {}, config = {}) {
 		},
 
 		error(error, url) {
-			log.error(` ${cyan('>')} ${url} - ${red('Failed to run')}`);
+			log.error(` ${styleText('cyan', '>')} ${url} - ${styleText('red', 'Failed to run')}`);
 		},
 
 		afterAll(report) {
 			const passRatio = `${report.passes}/${report.total} URLs passed`;
 
 			if (report.passes === report.total) {
-				log.info(green(`\n✔ ${passRatio}`));
+				log.info(styleText('green', `\n✔ ${passRatio}`));
 			} else {
 				// Now we loop over the errors and output them with
 				// word wrapping
 				const wrap = wordwrap(3, wrapWidth);
 				Object.keys(report.results).forEach(url => {
 					if (report.results[url].length) {
-						log.error(underline(`\nErrors in ${url}:`));
+						log.error(styleText('underline', `\nErrors in ${url}:`));
 						report.results[url].forEach(result => {
-							const redBullet = red('•');
+							const redBullet = styleText('red', '•');
 							if (result instanceof Error) {
 								log.error(`\n ${redBullet} Error: ${wrap(result.message).trim()}`);
 							} else {
@@ -81,15 +81,15 @@ module.exports = function cliReporter(options = {}, config = {}) {
 									'',
 									` ${redBullet} ${wrap(result.message).trim()}`,
 									'',
-									grey(wrap(`(${result.selector})`)),
+									styleText('gray', wrap(`(${result.selector})`)),
 									'',
-									grey(wrap(context))
+									styleText('gray', wrap(context))
 								].join('\n'));
 							}
 						});
 					}
 				});
-				log.error(red(`\n✘ ${passRatio}`));
+				log.error(styleText('red', `\n✘ ${passRatio}`));
 			}
 		}
 	};

--- a/package.json
+++ b/package.json
@@ -40,14 +40,13 @@
   "bugs": "https://github.com/pa11y/pa11y-ci/issues",
   "license": "LGPL-3.0-only",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "dependencies": {
     "async": "~3.2.6",
     "cheerio": "~1.0.0",
     "commander": "~14.0.3",
     "globby": "~6.1.0",
-    "kleur": "~4.1.5",
     "lodash": "~4.18.1",
     "node-fetch": "~2.7.0",
     "pa11y": "^9.1.1",


### PR DESCRIPTION
## Summary

Resolves #344.

 has had no commits in 4+ years and is effectively unmaintained. Node.js v22.13.0 shipped `util.styleText` as a stable API that covers all formatting currently done with kleur, with zero external dependencies.

## Changes

**`lib/reporters/cli.js`**
- Replaces `require('kleur')` with `const {styleText} = require('util')`
- All colour/style calls updated: `cyan(x)` → `styleText('cyan', x)`, `grey(x)` → `styleText('gray', x)`, etc.
- Combined style+colour (previously nested kleur calls like `cyan(underline(x))`) now use `styleText`'s array form: `styleText(['cyan', 'underline'], x)`

**`package.json`**
- Removes `kleur` from `dependencies`
- Bumps `engines.node` from `>=20` to `>=22` (Node 20 reached EOL on 2026-04-30; `util.styleText` became stable in Node v22.13.0)

## Testing

Existing unit tests for the CLI reporter (`test/unit/lib/reporters/cli.test.js`) test call patterns and log method routing rather than specific ANSI escape codes, so no test changes are required and the existing suite passes against the updated code.

## Related

- pa11y/pa11y#823 / pa11y/pa11y#834 — same change applied to pa11y core