### PR TITLE
Send configured headers with the sitemap request

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,9 @@ Pa11y will be run against the text content of each `<loc/>` in the sitemap's XML
 > [!NOTE]
 > Providing a sitemap will cause the `urls` property in your JSON config to be ignored.
 
+Any `headers` set in `defaults` are sent with the sitemap request as well as with
+the page loads, so a sitemap behind the same authentication can still be read.
+
 #### Transforming URLs retrieved from a sitemap before testing
 
 Pa11y CI can replace a string within each URL found in a sitemap, before beginning to test.  This can be useful when your sitemap contains production URLs, but you'd actually like to test

--- a/bin/pa11y-ci.js
+++ b/bin/pa11y-ci.js
@@ -213,10 +213,13 @@ function loadSitemapIntoConfig(program, initialConfig) {
 			new RegExp(program.sitemapExclude, 'gi') :
 			null
 	);
+	// Headers in the config are sent to Chrome for the page loads, so a
+	// sitemap behind the same auth needs them too
+	const sitemapHeaders = initialConfig.defaults.headers;
 
 	function getUrlsFromSitemap(sitemapUrl, config) {
 		return Promise.resolve()
-			.then(() => fetch(sitemapUrl))
+			.then(() => fetch(sitemapUrl, {headers: sitemapHeaders}))
 			.then(response => response.text())
 			.then(body => {
 				const $ = cheerio.load(body, {xmlMode: true});

--- a/test/integration/cli-sitemap.test.js
+++ b/test/integration/cli-sitemap.test.js
@@ -107,3 +107,40 @@ describe('pa11y-ci (with a sitemap being sitemapindex)', () => {
 	});
 
 });
+
+describe('pa11y-ci (with a sitemap that requires headers)', () => {
+
+	before(() => {
+		return global.cliCall([
+			'--sitemap',
+			'http://localhost:8090/sitemap-protected.xml',
+			'--config',
+			'sitemap-headers'
+		]);
+	});
+
+	it('sends the configured headers when fetching the sitemap', () => {
+		assert.include(global.lastResult.output, 'http://localhost:8090/passing-1');
+		assert.include(global.lastResult.output, 'http://localhost:8090/failing-1');
+	});
+
+});
+
+describe('pa11y-ci (with a sitemap that requires headers, none configured)', () => {
+
+	before(() => {
+		return global.cliCall([
+			'--sitemap',
+			'http://localhost:8090/sitemap-protected.xml',
+			'--config',
+			'empty'
+		]);
+	});
+
+	it('finds no URLs, which is what #254 reported', () => {
+		// The 403 body is not XML, so it parses as an empty sitemap and the
+		// run silently passes with nothing tested.
+		assert.include(global.lastResult.output, 'Running Pa11y on 0 URLs');
+	});
+
+});

--- a/test/integration/mock/config/sitemap-headers.json
+++ b/test/integration/mock/config/sitemap-headers.json
@@ -1,0 +1,7 @@
+{
+	"defaults": {
+		"headers": {
+			"x-test-secret": "let-me-in"
+		}
+	}
+}

--- a/test/integration/mock/website/index.js
+++ b/test/integration/mock/website/index.js
@@ -15,10 +15,16 @@ function startWebsite(port, done) {
 		const viewPath = path.join(__dirname, 'html', `${urlPath}.html`);
 
 		if (urlPath.includes('.xml')) {
+			// Stands in for a preview environment behind a bypass secret
+			if (urlPath.includes('protected') && request.headers['x-test-secret'] !== 'let-me-in') {
+				response.writeHead(403);
+				return response.end('Forbidden');
+			}
 			response.writeHead(200, {
 				'Content-Type': 'text/xml'
 			});
-			return response.end(fs.readFileSync(path.join(__dirname, urlPath), 'utf-8'));
+			const file = urlPath.replace('-protected', '');
+			return response.end(fs.readFileSync(path.join(__dirname, file), 'utf-8'));
 		}
 
 		try {


### PR DESCRIPTION
Closes #254.

`headers` in `defaults` were passed to Chrome for the page loads but not to the
`fetch` that retrieves the sitemap, which @aarongoldenthal confirmed in the
thread.

The failure is quiet, which is the worst part. A sitemap behind the same auth
returns a 403, that body is not XML, cheerio parses it as an empty sitemap, and
the run reports `Running Pa11y on 0 URLs` and exits 0. Nothing is tested and CI
still goes green, matching the original report of "0 URLs tested".

The fix reads `initialConfig.defaults.headers` and passes it to `fetch`.
`defaultConfig` always populates `defaults`, so no guard is needed, and the
recursive call for sitemap index files inherits it.

The mock website now serves any `*-protected.xml` path only when
`x-test-secret` is present, and two tests cover it:

- with headers configured, the sitemap URLs are found. This fails without the
  change with `Running Pa11y on 0 URLs`
- with none configured, it reports 0 URLs, pinning the reported behavior

`eslint` is clean, 59 unit and 70 integration tests pass.

Prior art: #183 proposed the same thing in 2022 and was closed without review
while the repo was quiet. This is written against current main.
