### PR TITLE
Fix config leak between concurrent tests

### DIFF
--- a/lib/pa11y-ci.js
+++ b/lib/pa11y-ci.js
@@ -109,7 +109,7 @@ function pa11yCi(urls, options) {
 			let url;
 			if (typeof config === 'string') {
 				url = config;
-				config = options;
+				config = defaults({}, options);
 			} else {
 				({url} = config);
 				config = defaults({}, config, options);


### PR DESCRIPTION
Fixes #354.

Prevent config object from being shared between tests which are run in parallel.